### PR TITLE
Add Cloudflare Worker fallback support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,65 @@ on:
       - main
       - master
       - feature/**
+    tags:
+      - v[0-9]+.*
   pull_request:
 
 jobs:
+  release-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check release version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          read_version() {
+            python3 -c 'import sys, tomllib; print(tomllib.load(open(sys.argv[1], "rb"))["package"]["version"])' "$1"
+          }
+
+          compare_versions() {
+            python3 -c 'import sys; current = tuple(map(int, sys.argv[1].split("."))); base = tuple(map(int, sys.argv[2].split("."))); sys.exit(0 if current > base else 1)' "$1" "$2"
+          }
+
+          current_version="$(read_version Cargo.toml)"
+          if [[ ! "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error file=Cargo.toml::package.version must be numeric X.Y.Z, got '$current_version'"
+            exit 1
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}"
+            git show "origin/${GITHUB_BASE_REF}:Cargo.toml" > /tmp/base-Cargo.toml
+            base_version="$(read_version /tmp/base-Cargo.toml)"
+
+            if [[ ! "$base_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::base package.version must be numeric X.Y.Z, got '$base_version'"
+              exit 1
+            fi
+
+            if ! compare_versions "$current_version" "$base_version"; then
+              echo "::error file=Cargo.toml::package.version must be greater than base branch version ($base_version), got '$current_version'"
+              exit 1
+            fi
+
+            echo "Release version OK: $base_version -> $current_version"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag_version="${GITHUB_REF_NAME#v}"
+            if [[ "$current_version" != "$tag_version" ]]; then
+              echo "::error file=Cargo.toml::tag ${GITHUB_REF_NAME} does not match package.version $current_version"
+              exit 1
+            fi
+
+            echo "Release tag OK: ${GITHUB_REF_NAME} matches Cargo.toml"
+          else
+            echo "Release version check skipped for ${GITHUB_EVENT_NAME} on ${GITHUB_REF_NAME}"
+          fi
+
   rust:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "aes",
  "cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ tunnels them through WebSocket (TLS) connections to Telegram's DC servers.
 ```
 Telegram Desktop → MTProto (TCP 1443) → tg-ws-proxy-rs → WS (TLS 443) → Telegram DC
                                                          ↘ CF proxy (kws{N}.{cf-domain}) → Telegram DC  (WS via Cloudflare)
+                                                         ↘ CF Worker (*.workers.dev) → Telegram DC  (TCP tunnel via Cloudflare)
                                                          ↘ upstream MTProto proxy → Telegram DC  (WS fallback)
                                                          ↘ direct TCP :443 → Telegram DC          (last resort)
 ```
@@ -100,6 +101,7 @@ tg-ws-proxy [OPTIONS]
 | `--buf-kb <KB>` | `256` | Socket buffer size |
 | `--pool-size <N>` | `4` | Pre-warmed WS connections per DC |
 | `--cf-domain <DOMAIN>` | — | Cloudflare-proxied domain(s) for alternative WS routing, comma-separated (see [CF Proxy](#cloudflare-proxy)) |
+| `--cf-worker-domain <DOMAIN>` | — | Cloudflare Worker domain for TCP-tunnel fallback, no owned domain required (see [Cloudflare Worker](#cloudflare-worker)) |
 | `--default-domains` | off | Fetch and use the built-in CF proxy domain list from GitHub (no Cloudflare setup needed, see [Default domains](#default-domains)) |
 | `--cf-priority` | off | Try CF proxy **before** direct WS for all DCs (see [CF Proxy](#cloudflare-proxy)) |
 | `--cf-balance` | off | Round-robin load balance across multiple `--cf-domain` values (see [CF Proxy](#cloudflare-proxy)) |
@@ -113,7 +115,8 @@ tg-ws-proxy [OPTIONS]
 Every flag has a matching environment variable (`TG_PORT`, `TG_HOST`,
 `TG_SECRET`, `TG_BUF_KB`, `TG_POOL_SIZE`, `TG_MAX_CONNECTIONS`, `TG_QUIET`,
 `TG_VERBOSE`, `TG_SKIP_TLS_VERIFY`, `TG_LINK_IP`, `TG_LISTEN_FAKETLS_DOMAIN`, `TG_MTPROTO_PROXY`,
-`TG_LOG_FILE`, `TG_CF_DOMAIN`, `TG_CF_PRIORITY`, `TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`).
+`TG_LOG_FILE`, `TG_CF_DOMAIN`, `TG_CF_WORKER_DOMAIN`, `TG_CF_PRIORITY`,
+`TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`).
 
 ### Examples
 
@@ -129,6 +132,9 @@ tg-ws-proxy --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef123456
 
 # With Cloudflare proxy domain (WS fallback via Cloudflare CDN)
 tg-ws-proxy --cf-domain yourdomain.com
+
+# With Cloudflare Worker (free workers.dev TCP tunnel fallback)
+tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev
 
 # CF proxy only: omit --dc-ip so CF proxy handles all DCs
 tg-ws-proxy --cf-domain yourdomain.com --cf-priority
@@ -273,9 +279,9 @@ tg-ws-proxy --dc-ip 2:149.154.167.220 --cf-domain yourdomain.com --cf-priority
 TG_CF_DOMAIN=yourdomain.com tg-ws-proxy
 ```
 
-The proxy will try the CF path as a fallback after direct WebSocket fails, and
-as the primary path for DCs that have no `--dc-ip` configured.  With
-`--cf-priority`, the CF proxy is tried **before** direct WebSocket for all DCs.
+The proxy will try the CF path as a fallback after direct WebSocket fails.
+With `--cf-priority`, the CF proxy is tried **before** direct WebSocket for all
+DCs.
 
 #### `--cf-balance` — round-robin load balancing
 
@@ -320,6 +326,36 @@ tg-ws-proxy --cf-domain d1.example.com,d2.example.com --cf-balance --cf-priority
    | `kws203-1`| `91.105.192.100`  |
 
 See [docs/CfProxy.md](docs/CfProxy.md) for full instructions.
+
+### Cloudflare Worker
+
+Cloudflare Worker mode is an alternative to `--cf-domain` when you do not own
+a domain. Deploy the Worker script from [docs/CfWorker.md](docs/CfWorker.md),
+copy its `*.workers.dev` domain, and pass it to the proxy:
+
+```bash
+tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev
+```
+
+Or via environment variable:
+
+```bash
+TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev tg-ws-proxy
+```
+
+The Worker accepts an outer WebSocket connection from `tg-ws-proxy-rs`, opens a
+raw TCP connection to the selected Telegram DC IP, and forwards WebSocket
+message payloads as TCP bytes:
+
+```
+tg-ws-proxy-rs → wss://<worker>/apiws?dst=<dc-ip>&dc=<dc>&media=<0|1>
+Cloudflare Worker → TCP <dc-ip>:443
+```
+
+For DCs with a configured direct WebSocket target, direct WS is tried first and
+the Worker is used only after that path fails. For DCs without a direct WS
+target, the Worker is tried before the regular Cloudflare proxy/default
+domains and the remaining fallbacks.
 
 ### Default domains
 
@@ -478,15 +514,17 @@ chmod +x /etc/init.d/tg-ws-proxy
    IP).
 4. The relay init packet is sent to Telegram, and bidirectional bridging
    begins with AES-256-CTR re-encryption (client keys ↔ relay keys).
-5. If WebSocket is unavailable, the proxy tries the Cloudflare proxy path
-   (`wss://kwsN.{cf-domain}/apiws`) if `--cf-domain` is configured —
-   Cloudflare terminates TLS and forwards plain WebSocket traffic to Telegram.
-6. If CF proxy is unavailable or not configured, each upstream MTProto proxy
+5. If WebSocket is unavailable and Cloudflare Worker is configured, the proxy can open
+   `wss://<worker>/apiws?dst=<dc-ip>` and tunnel raw TCP traffic to the DC via
+   the Worker.
+6. If Worker is unavailable or not configured, the proxy tries the Cloudflare
+   proxy path (`wss://kwsN.{cf-domain}/apiws`) if `--cf-domain` is configured.
+7. If CF paths are unavailable or not configured, each upstream MTProto proxy
    is tried in order (generating a fresh client handshake with the upstream's
    secret so it can route to the correct DC).
-7. If no upstream proxy is configured or all fail, the proxy falls back to
+8. If no upstream proxy is configured or all fail, the proxy falls back to
    direct TCP on port 443.
-8. A small pool of pre-connected WebSocket connections is maintained per DC to
+9. A small pool of pre-connected WebSocket connections is maintained per DC to
    reduce connection latency for subsequent clients.
 
 ## Project structure
@@ -502,6 +540,9 @@ src/
   pool.rs              — Pre-warmed WebSocket connection pool per DC
   proxy.rs             — Client handler, re-encryption bridge, TCP fallback logic
   default_domains.rs   — Fetches and deobfuscates the default CF proxy domain list
+docs/
+  CfProxy.md           — Cloudflare DNS proxy setup
+  CfWorker.md          — Cloudflare Worker TCP tunnel setup
 .cargo/
   config.toml          — Cross-compilation target presets (commented out)
 ```
@@ -518,6 +559,7 @@ TG_MAX_CONNECTIONS=64
 TG_QUIET=true
 TG_VERBOSE=false
 TG_CF_DOMAIN=yourdomain.com
+TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev
 TG_CF_PRIORITY=false
 TG_CF_BALANCE=false
 TG_DEFAULT_DOMAINS=false

--- a/docs/CfProxy.md
+++ b/docs/CfProxy.md
@@ -90,7 +90,7 @@ When `--cf-domain` is configured the proxy:
    configured) and finally direct TCP.
 
 When no `--dc-ip` is configured for a DC, the CF proxy is tried as the
-**primary** path (before upstreams / TCP fallback).  If `--dc-ip` is omitted
+**primary** path (before upstreams / TCP fallback). If `--dc-ip` is omitted
 entirely and `--cf-domain` is set, CF proxy becomes the primary path for
 **all** DCs.
 

--- a/docs/CfWorker.md
+++ b/docs/CfWorker.md
@@ -1,0 +1,134 @@
+# Cloudflare Worker
+
+Альтернативный (полностью бесплатный, не нужно покупать домен в отличии от [CfProxy](./CfProxy.md)) способ проксирования.
+
+Прокси возвращает доступ к тому, что раньше не загружалось (реакции, некоторые стикеры). Если на аккаунте без Premium с данным способом все еще не загружаются фото/видео, оставьте в блоке `DC -> IP` только `4:149.154.167.220`
+
+##
+
+1. **Добавьте в [zapret](https://github.com/Flowseal/zapret-discord-youtube/) или в любое другое ПО следующие домены:**
+```
+cloudflare.com
+cloudflare.dev
+workers.dev
+```
+2. Создайте аккаунт в [Cloudflare](https://dash.cloudflare.com/) (или войдите в существующий)
+    * **После создания аккаунта подтвердите почту с помощью письма, который вам пришел на email**
+3. Слева в панели выберите `Compute` -> `Workers & Pages`
+   <img width="250" height="768" alt="image" src="https://github.com/user-attachments/assets/d81e3522-045a-4e65-9c2e-5545b7ad409a" />
+
+4. Нажмите сверху справа кнопку **`Create application`** -> `Start with Hello World!` -> `Deploy`
+   <img width="1406" height="193" alt="image" src="https://github.com/user-attachments/assets/7ac65944-8761-42a6-ab6d-ba5f9080c883" />
+   <img width="586" height="379" alt="image" src="https://github.com/user-attachments/assets/ff901439-c2a1-4867-95de-e11b82a37044" />
+   <img width="624" height="694" alt="image" src="https://github.com/user-attachments/assets/bb68d49a-166d-42a0-8fe2-bd2b16c0d066" />
+
+5. Сверху справа нажмите кнопку **`Edit code`**, замените код слева на тот, [что находится внизу этой страницы](./CfWorker.md#код-workerа)
+    * Если у вас не загружается код, то вы не выполнили первый пункт
+    <img width="911" height="117" alt="image" src="https://github.com/user-attachments/assets/6bcdf839-d776-47e9-9d18-ba0efdf53244" />
+    <img width="1027" height="512" alt="image" src="https://github.com/user-attachments/assets/daf131ed-82d5-40f0-a7eb-daeb598bea40" />
+
+6. Нажмите сверху справа кнопку **`Deploy`**
+   <img width="415" height="138" alt="image" src="https://github.com/user-attachments/assets/58d8f83e-d8b5-40cf-a30f-741d7311047b" />
+
+7. Скопируйте домен из поля справа и укажите его в настройках **Cloudflare Worker** (или через аргумент `--cf-worker-domain`; совместимое имя из Python `--cfproxy-worker-domain` тоже поддерживается)
+    * Пример домена: `random-symbols-1234.username.workers.dev`
+   <img width="414" height="182" alt="image" src="https://github.com/user-attachments/assets/4fb0b111-8026-4d17-b993-6c70ec37f1f5" />
+
+В Docker / systemd можно использовать переменную окружения:
+
+```bash
+TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev
+```
+
+Проверить Worker перед запуском прокси:
+
+```bash
+tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev --check
+```
+
+### Код Worker'а
+```javascript
+import { connect } from "cloudflare:sockets";
+
+function toBytes(data) {
+	if (data instanceof ArrayBuffer) {
+		return new Uint8Array(data);
+	}
+	if (typeof data === "string") {
+		return new TextEncoder().encode(data);
+	}
+	if (data && typeof data.arrayBuffer === "function") {
+		return data.arrayBuffer().then((ab) => new Uint8Array(ab));
+	}
+	return new Uint8Array();
+}
+
+export default {
+	async fetch(request) {
+		if ((request.headers.get("Upgrade") || "").toLowerCase() !== "websocket") {
+			return new Response("Expected websocket", { status: 426 });
+		}
+
+		const url = new URL(request.url);
+		if (url.pathname !== "/apiws") {
+			return new Response("Not found", { status: 404 });
+		}
+
+		const dst = url.searchParams.get("dst");
+		const pair = new WebSocketPair();
+		const client = pair[0];
+		const server = pair[1];
+		server.accept();
+
+		const socket = connect({ hostname: dst, port: 443 });
+		const tcpReader = socket.readable.getReader();
+		const tcpWriter = socket.writable.getWriter();
+
+		server.addEventListener("message", async (event) => {
+			try {
+				await tcpWriter.write(await toBytes(event.data));
+			} catch {
+				try {
+					server.close(1011, "tcp write failed");
+				} catch {}
+			}
+		});
+
+		server.addEventListener("close", async () => {
+			try {
+				await tcpWriter.close();
+			} catch {}
+			try {
+				socket.close();
+			} catch {}
+		});
+
+		(async () => {
+			try {
+				while (true) {
+					const { value, done } = await tcpReader.read();
+					if (done) {
+						break;
+					}
+					if (value) {
+						server.send(value);
+					}
+				}
+			} catch {
+			} finally {
+				try {
+					server.close();
+				} catch {}
+				try {
+					tcpReader.releaseLock();
+				} catch {}
+				try {
+					socket.close();
+				} catch {}
+			}
+		})();
+
+		return new Response(null, { status: 101, webSocket: client });
+	},
+};
+```

--- a/src/check.rs
+++ b/src/check.rs
@@ -27,10 +27,10 @@ use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
-use crate::config::{Config, MtProtoProxy};
+use crate::config::{Config, MtProtoProxy, default_dc_ips};
 use crate::crypto::{ProtoTag, generate_client_handshake};
 use crate::faketls;
-use crate::ws_client::connect_cf_ws_for_dc;
+use crate::ws_client::{connect_cf_worker_ws_for_dc, connect_cf_ws_for_dc};
 
 // ─── Probe result ─────────────────────────────────────────────────────────────
 
@@ -74,6 +74,23 @@ async fn probe_cf_domain(domain: &str, skip_tls: bool, timeout: Duration) -> Pro
     } else {
         ProbeStatus::Fail(
             "WebSocket connection failed — check DNS records and Cloudflare settings".to_string(),
+        )
+    }
+}
+
+/// Probe a Cloudflare Worker by opening its WebSocket tunnel to DC 2.
+async fn probe_cf_worker(domain: &str, skip_tls: bool, timeout: Duration) -> ProbeStatus {
+    let Some(dst) = default_dc_ips().get(&2).cloned() else {
+        return ProbeStatus::Fail("DC 2 default IP is missing".to_string());
+    };
+
+    let start = Instant::now();
+    let ws = connect_cf_worker_ws_for_dc(domain, &dst, 2, false, skip_tls, timeout).await;
+    if ws.is_some() {
+        ProbeStatus::Ok(start.elapsed())
+    } else {
+        ProbeStatus::Fail(
+            "Worker WebSocket tunnel failed — check Worker code and domain".to_string(),
         )
     }
 }
@@ -187,10 +204,15 @@ pub async fn run_check(config: &Config) -> bool {
     println!("  tg-ws-proxy connectivity check");
     println!("{}", sep);
 
-    if config.cf_domains.is_empty() && config.mtproto_proxies.is_empty() {
+    let cf_worker_domain = config.cf_worker_domain();
+
+    if config.cf_domains.is_empty()
+        && cf_worker_domain.is_none()
+        && config.mtproto_proxies.is_empty()
+    {
         println!();
         println!("  Nothing to check.");
-        println!("  Configure --cf-domain and/or --mtproto-proxy and re-run.");
+        println!("  Configure --cf-domain, --cf-worker-domain and/or --mtproto-proxy and re-run.");
         println!("{}", sep);
         return true;
     }
@@ -213,6 +235,21 @@ pub async fn run_check(config: &Config) -> bool {
             if !status.is_ok() {
                 all_ok = false;
             }
+        }
+    }
+
+    // ── Cloudflare Worker probe ──────────────────────────────────────────
+    if let Some(domain) = cf_worker_domain {
+        println!();
+        println!("Cloudflare Worker (DC2 TCP tunnel probe):");
+        print!("  {:40}  ... ", domain);
+        let _ = std::io::Write::flush(&mut std::io::stdout());
+
+        let status = probe_cf_worker(&domain, skip_tls, cf_timeout).await;
+        println!("[{}]  {}", status.marker(), status.detail());
+
+        if !status.is_ok() {
+            all_ok = false;
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,7 +195,8 @@ pub struct Config {
     /// tried in the order given (first domain has highest priority).
     ///
     /// The CF proxy is tried as a fallback after direct WebSocket connections
-    /// fail, and as the primary path when no `--dc-ip` is configured for a DC.
+    /// fail. For DCs without `--dc-ip`, the Python fallback order is used:
+    /// Worker, regular CF proxy, upstream proxies, then direct TCP.
     #[arg(
         long = "cf-domain",
         value_name = "DOMAIN",
@@ -203,6 +204,19 @@ pub struct Config {
         env = "TG_CF_DOMAIN"
     )]
     pub cf_domains: Vec<String>,
+
+    /// Cloudflare Worker domain for the TCP-tunnel fallback.
+    ///
+    /// The Worker accepts WebSocket connections at `/apiws` and opens a raw
+    /// TCP connection to the Telegram DC IP passed in the query string. Unlike
+    /// `--cf-domain`, this does not require owning a Cloudflare DNS zone.
+    #[arg(
+        long = "cf-worker-domain",
+        alias = "cfproxy-worker-domain",
+        value_name = "DOMAIN",
+        env = "TG_CF_WORKER_DOMAIN"
+    )]
+    pub cf_worker_domain: Option<String>,
 
     /// Prioritise Cloudflare proxy over direct WebSocket connections for all
     /// DCs (even those with `--dc-ip` configured).
@@ -418,6 +432,30 @@ impl Config {
     /// Map of DC ID → target IP from `--dc-ip` flags.
     pub fn dc_redirects(&self) -> HashMap<u32, String> {
         self.dc_ip.iter().cloned().collect()
+    }
+
+    /// Cloudflare Worker domain normalized for `Host` and TLS SNI use.
+    pub fn cf_worker_domain(&self) -> Option<String> {
+        let domain = self.cf_worker_domain.as_deref()?.trim();
+        if domain.is_empty() {
+            return None;
+        }
+
+        let domain = domain
+            .strip_prefix("https://")
+            .or_else(|| domain.strip_prefix("http://"))
+            .unwrap_or(domain);
+        let domain = domain
+            .split_once('/')
+            .map(|(host, _)| host)
+            .unwrap_or(domain)
+            .trim_end_matches('/');
+
+        if domain.is_empty() {
+            None
+        } else {
+            Some(domain.to_string())
+        }
     }
 
     /// The hostname/IP to advertise in the generated `tg://proxy` link.

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,6 +216,10 @@ async fn main() {
         }
     }
 
+    if let Some(worker_domain) = config.cf_worker_domain() {
+        info!("  Cloudflare Worker: {}", worker_domain);
+    }
+
     if !config.mtproto_proxies.is_empty() {
         info!("  Upstream MTProto proxies (WS fallback):");
         for p in &config.mtproto_proxies {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -43,7 +43,9 @@ use crate::faketls::{
 };
 use crate::pool::WsPool;
 use crate::splitter::MsgSplitter;
-use crate::ws_client::{TgWsStream, connect_cf_ws_for_dc, connect_ws_for_dc, ws_send};
+use crate::ws_client::{
+    TgWsStream, connect_cf_worker_ws_for_dc, connect_cf_ws_for_dc, connect_ws_for_dc, ws_send,
+};
 
 // WS failure cooldown is global for the process lifetime.
 use std::collections::HashMap;
@@ -124,6 +126,8 @@ fn balanced_cf_domains(cf_domains: &[String]) -> Vec<String> {
 
 /// Per-DC cooldown for the CF proxy path.
 static CF_FAIL_UNTIL: StdMutex<Option<HashMap<(u32, bool), Instant>>> = StdMutex::new(None);
+/// Per-DC cooldown for the Cloudflare Worker path.
+static CF_WORKER_FAIL_UNTIL: StdMutex<Option<HashMap<(u32, bool), Instant>>> = StdMutex::new(None);
 type TcpReader = ReadHalf<TcpStream>;
 type TcpWriter = WriteHalf<TcpStream>;
 
@@ -146,6 +150,29 @@ fn cf_in_cooldown(dc: u32, is_media: bool) -> bool {
         if let Some(&until) = map.get(&(dc, is_media)) {
             return Instant::now() < until;
         }
+    }
+    false
+}
+
+fn set_cf_worker_cooldown(dc: u32, is_media: bool, cooldown: Duration) {
+    let mut lock = CF_WORKER_FAIL_UNTIL.lock().unwrap();
+    lock.get_or_insert_with(HashMap::new)
+        .insert((dc, is_media), Instant::now() + cooldown);
+}
+
+fn clear_cf_worker_cooldown(dc: u32, is_media: bool) {
+    let mut lock = CF_WORKER_FAIL_UNTIL.lock().unwrap();
+    if let Some(map) = lock.as_mut() {
+        map.remove(&(dc, is_media));
+    }
+}
+
+fn cf_worker_in_cooldown(dc: u32, is_media: bool) -> bool {
+    let lock = CF_WORKER_FAIL_UNTIL.lock().unwrap();
+    if let Some(map) = lock.as_ref()
+        && let Some(&until) = map.get(&(dc, is_media))
+    {
+        return Instant::now() < until;
     }
     false
 }
@@ -414,10 +441,13 @@ pub async fn handle_client(
 
     // ── Step 5: route the connection ──────────────────────────────────────
     let target_ip = dc_redirects.get(&dc_id).cloned();
+    let cf_worker_domain = config.cf_worker_domain();
     let media_tag = if is_media { "m" } else { "" };
 
     if target_ip.is_none() {
-        // DC not in config — try CF proxy, then upstream proxies, then TCP fallback.
+        // DC not in config — match the Python fallback order:
+        // CF Worker, CF proxy/default domains, then TCP fallback.  Rust keeps
+        // upstream MTProto proxies before TCP as an extra fallback tier.
         let reason = format!("DC{} not in --dc-ip config", dc_id);
         let fallback = match dc_fallback_ips.get(&dc_id) {
             Some(ip) => ip.clone(),
@@ -426,6 +456,52 @@ pub async fn handle_client(
                 return;
             }
         };
+
+        // ── Try Cloudflare Worker if configured ──────────────────────────
+        if let Some(worker_domain) = cf_worker_domain.as_deref() {
+            if !cf_worker_in_cooldown(dc_id, is_media) {
+                debug!(
+                    "[{}] DC{}{} {} → trying CF Worker {} for {}",
+                    label, dc_id, media_tag, reason, worker_domain, fallback
+                );
+
+                if let Some(ws) = connect_cf_worker_ws_for_dc(
+                    worker_domain,
+                    &fallback,
+                    dc_id,
+                    is_media,
+                    skip_tls,
+                    cf_connect_timeout,
+                )
+                .await
+                {
+                    clear_cf_worker_cooldown(dc_id, is_media);
+                    info!(
+                        "[{}] DC{}{} {} → CF Worker connected",
+                        label, dc_id, media_tag, reason
+                    );
+                    bridge_ws(
+                        &label, reader, writer, ws, relay_init, ciphers, proto, dc_id, is_media,
+                    )
+                    .await;
+                    return;
+                } else {
+                    set_cf_worker_cooldown(dc_id, is_media, cf_fail_cooldown);
+                    warn!(
+                        "[{}] DC{}{} CF Worker failed, cooldown {}s",
+                        label,
+                        dc_id,
+                        media_tag,
+                        cf_fail_cooldown.as_secs()
+                    );
+                }
+            } else {
+                debug!(
+                    "[{}] DC{}{} CF Worker in cooldown, skipping",
+                    label, dc_id, media_tag
+                );
+            }
+        }
 
         // ── Try Cloudflare proxy if configured ────────────────────────────
         if !config.cf_domains.is_empty() {
@@ -679,6 +755,50 @@ pub async fn handle_client(
                     );
                 }
 
+                // ── Try Cloudflare Worker if configured ──────────────────
+                if let Some(worker_domain) = cf_worker_domain.as_deref() {
+                    if !cf_worker_in_cooldown(dc_id, is_media) {
+                        debug!(
+                            "[{}] DC{}{} WS failed → trying CF Worker {} for {}",
+                            label, dc_id, media_tag, worker_domain, target_ip
+                        );
+
+                        if let Some(ws) = connect_cf_worker_ws_for_dc(
+                            worker_domain,
+                            &target_ip,
+                            dc_id,
+                            is_media,
+                            skip_tls,
+                            cf_connect_timeout,
+                        )
+                        .await
+                        {
+                            clear_cf_worker_cooldown(dc_id, is_media);
+                            info!("[{}] DC{}{} → CF Worker connected", label, dc_id, media_tag);
+                            bridge_ws(
+                                &label, reader, writer, ws, relay_init, ciphers, proto, dc_id,
+                                is_media,
+                            )
+                            .await;
+                            return;
+                        } else {
+                            set_cf_worker_cooldown(dc_id, is_media, cf_fail_cooldown);
+                            warn!(
+                                "[{}] DC{}{} CF Worker failed, cooldown {}s",
+                                label,
+                                dc_id,
+                                media_tag,
+                                cf_fail_cooldown.as_secs()
+                            );
+                        }
+                    } else {
+                        debug!(
+                            "[{}] DC{}{} CF Worker in cooldown, skipping",
+                            label, dc_id, media_tag
+                        );
+                    }
+                }
+
                 // ── Try Cloudflare proxy if configured ────────────────────
                 // (Skip if --cf-priority already tried the CF path above.)
                 if !config.cf_priority && !config.cf_domains.is_empty() {
@@ -689,7 +809,7 @@ pub async fn handle_client(
                             config.cf_domains.clone()
                         };
                         debug!(
-                            "[{}] DC{}{} WS failed → trying CF proxy",
+                            "[{}] DC{}{} WS/Worker failed → trying CF proxy",
                             label, dc_id, media_tag
                         );
 

--- a/src/ws_client.rs
+++ b/src/ws_client.rs
@@ -87,6 +87,17 @@ pub async fn connect_ws(
     skip_tls_verify: bool,
     timeout: Duration,
 ) -> WsConnectResult {
+    connect_ws_with_path(ip, domain, "/apiws", true, skip_tls_verify, timeout).await
+}
+
+async fn connect_ws_with_path(
+    ip: &str,
+    domain: &str,
+    path: &str,
+    request_binary_subprotocol: bool,
+    skip_tls_verify: bool,
+    timeout: Duration,
+) -> WsConnectResult {
     // ── TCP connection to the configured IP ──────────────────────────────
     let tcp = match tokio::time::timeout(timeout, TcpStream::connect(format!("{}:443", ip))).await {
         Ok(Ok(s)) => s,
@@ -98,7 +109,7 @@ pub async fn connect_ws(
     let _ = tcp.set_nodelay(true);
 
     // ── Build WebSocket request with Telegram-required headers ───────────
-    let url = format!("wss://{}/apiws", domain);
+    let url = format!("wss://{}{}", domain, path);
     let mut request = match url.into_client_request() {
         Ok(r) => r,
         Err(e) => return WsConnectResult::Failed(format!("bad URL: {}", e)),
@@ -106,7 +117,9 @@ pub async fn connect_ws(
     {
         let h = request.headers_mut();
 
-        h.insert("Sec-WebSocket-Protocol", HeaderValue::from_static("binary"));
+        if request_binary_subprotocol {
+            h.insert("Sec-WebSocket-Protocol", HeaderValue::from_static("binary"));
+        }
         h.insert(
             "Origin",
             HeaderValue::from_static("https://web.telegram.org"),
@@ -160,6 +173,19 @@ pub async fn connect_ws(
         }
         Err(_) => WsConnectResult::Failed("WebSocket handshake timed out".into()),
     }
+}
+
+/// Path used by the Cloudflare Worker TCP-tunnel mode.
+///
+/// The Worker accepts a WebSocket at `/apiws`, opens a raw TCP connection to
+/// `dst:443`, and forwards every WebSocket message payload as TCP bytes.
+pub fn cf_worker_path(dst: &str, dc: u32, is_media: bool) -> String {
+    format!(
+        "/apiws?dst={}&dc={}&media={}",
+        dst,
+        dc,
+        if is_media { 1 } else { 0 }
+    )
 }
 
 /// Return `true` when `reason` describes a DNS lookup failure.
@@ -372,6 +398,63 @@ pub async fn connect_cf_ws_for_dc(
     }
 
     (None, all_redirects)
+}
+
+/// Connect through a Cloudflare Worker TCP tunnel.
+///
+/// Unlike `--cf-domain`, the Worker does not expose `kws{N}` subdomains.  We
+/// connect to the Worker domain and pass the real Telegram DC destination in
+/// the query string. The returned stream is the outer WebSocket to the Worker;
+/// the Worker forwards its binary frames to Telegram as raw TCP bytes.
+pub async fn connect_cf_worker_ws_for_dc(
+    worker_domain: &str,
+    dst: &str,
+    dc: u32,
+    is_media: bool,
+    skip_tls_verify: bool,
+    timeout: Duration,
+) -> Option<TgWsStream> {
+    let path = cf_worker_path(dst, dc, is_media);
+    debug!(
+        "CF Worker trying DC{}{} → {} via {}",
+        dc,
+        if is_media { "m" } else { "" },
+        dst,
+        worker_domain
+    );
+
+    match connect_ws_with_path(
+        worker_domain,
+        worker_domain,
+        &path,
+        false,
+        skip_tls_verify,
+        timeout,
+    )
+    .await
+    {
+        WsConnectResult::Connected(ws) => Some(ws),
+        WsConnectResult::Redirect(code) => {
+            warn!(
+                "CF Worker DC{}{} got {} from {} (redirect)",
+                dc,
+                if is_media { "m" } else { "" },
+                code,
+                worker_domain
+            );
+            None
+        }
+        WsConnectResult::Failed(reason) => {
+            warn!(
+                "CF Worker DC{}{} failed on {}: {}",
+                dc,
+                if is_media { "m" } else { "" },
+                worker_domain,
+                reason
+            );
+            None
+        }
+    }
 }
 
 /// Send a binary WebSocket message and flush.

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -40,3 +40,20 @@ fn plain_secret_still_generates_dd_link() {
     assert_eq!(cfg.listen_faketls_domain(), None);
     assert_eq!(cfg.link_secret(), format!("dd{}", key));
 }
+
+#[test]
+fn cf_worker_domain_accepts_python_alias_and_normalizes_url() {
+    // The Python reference uses --cfproxy-worker-domain; keep that spelling
+    // working while advertising the shorter Rust-style --cf-worker-domain.
+    let cfg = Config::try_parse_from([
+        "tg-ws-proxy",
+        "--cfproxy-worker-domain",
+        "https://example.user.workers.dev/apiws",
+    ])
+    .unwrap();
+
+    assert_eq!(
+        cfg.cf_worker_domain().as_deref(),
+        Some("example.user.workers.dev")
+    );
+}

--- a/tests/ws_client.rs
+++ b/tests/ws_client.rs
@@ -1,0 +1,10 @@
+use tg_ws_proxy_rs::ws_client::cf_worker_path;
+
+#[test]
+fn cf_worker_path_carries_destination_dc_and_media_flag() {
+    // The Worker is a TCP tunnel: dst tells it which Telegram DC IP to open,
+    // while dc/media are kept for compatibility with the Python Worker code.
+    let path = cf_worker_path("149.154.167.51", 2, true);
+
+    assert_eq!(path, "/apiws?dst=149.154.167.51&dc=2&media=1");
+}


### PR DESCRIPTION
## Что сделано

Добавлена поддержка Cloudflare Worker как fallback-маршрута для `tg-ws-proxy-rs`.

Worker используется как TCP-туннель: `tg-ws-proxy-rs` открывает WebSocket к `*.workers.dev`, передаёт нужный Telegram DC IP в query string, а Worker открывает TCP-соединение к этому DC и прокидывает бинарные данные между WebSocket и TCP.

Closes #54.

## Изменения

- Добавлен параметр `--cf-worker-domain <DOMAIN>`.
- Добавлена переменная окружения `TG_CF_WORKER_DOMAIN`.
- Добавлен совместимый с Python-версией alias `--cfproxy-worker-domain`.
- Worker domain нормализуется: можно передать hostname или URL вида `https://example.workers.dev/apiws`.
- Добавлен отдельный WebSocket-путь для Worker:
  - обычный WS к Telegram продолжает использовать `/apiws` и `Sec-WebSocket-Protocol: binary`;
  - Worker-путь использует `/apiws?dst=<ip>&dc=<dc>&media=<0|1>`;
  - для Worker не запрашивается `binary` subprotocol, так как Worker из Python-реализации его не возвращает.
- Добавлен fallback через Worker в routing logic:
  - если для DC нет прямого WS target, сначала пробуется Cloudflare Worker;
  - если прямой WS target есть, Worker пробуется после ошибки direct WS;
  - после Worker сохраняются существующие fallback-маршруты: CF proxy/default domains, upstream MTProto proxy и direct TCP.
- Добавлен отдельный cooldown для Worker fallback.
- В `--check` добавлена проверка Cloudflare Worker через DC2 TCP tunnel probe.
- В стартовый лог добавлен вывод настроенного Cloudflare Worker domain.
- Добавлена документация `docs/CfWorker.md` с Worker-кодом, приведённым к Python-реализации.
- Обновлены README и `docs/CfProxy.md` под новый Worker fallback.
- Добавлены тесты:
  - нормализация Worker domain;
  - совместимость alias `--cfproxy-worker-domain`;
  - генерация Worker path с `dst`, `dc` и `media`.
- Версия пакета обновлена до `1.5.0`.

## CI

В CI добавлена проверка release version:

- `Cargo.toml` должен содержать numeric semver `X.Y.Z`;
- в PR версия должна быть больше версии base branch;
- при push tag `vX.Y.Z` tag должен совпадать с `package.version`.

Также workflow теперь запускается для tag push вида `v[0-9]+.*`.

## Проверка

```bash
cargo fmt --check
cargo test --locked --tests
cargo clippy --all-targets --locked
```
