### PR TITLE
fix: bind and link address now agree when --host is omitted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and humans) working in this repository.
+
+## What this project is
+
+`tg-ws-proxy-rs` is a Rust port of [Flowseal/tg-ws-proxy](https://github.com/Flowseal/tg-ws-proxy): a local
+MTProto proxy that tunnels Telegram Desktop traffic through WebSocket connections to Telegram's
+data centers. It exists for networks where raw TCP to Telegram is blocked but WebSocket/HTTPS to
+`web.telegram.org` still works (common in Russia and other censored networks).
+
+At a high level: a Telegram client (Desktop, or any MTProto-speaking client) connects to this
+proxy over plain MTProto (optionally disguised as FakeTLS). The proxy de-obfuscates the MTProto
+transport frame, re-encrypts it for the target DC, and forwards it — preferring a WebSocket
+tunnel to `wss://kwsN.web.telegram.org/apiws`, with Cloudflare-proxy, Cloudflare-Worker, upstream
+MTProto proxy, and raw TCP as successive fallbacks.
+
+## Repository layout
+
+```
+src/
+  main.rs              Entry point: CLI parsing, socket bind, startup banner, connection accept loop
+  config.rs            clap-derived Config struct; all CLI flags + TG_* env var fallbacks
+  proxy.rs              Core per-connection logic: client handshake, DC routing, WS/CF/TCP fallback chain
+  crypto.rs             MTProto obfuscated-transport crypto (AES-256-CTR key derivation)
+  faketls.rs            0xee FakeTLS camouflage: fake TLS 1.3 handshake for inbound + upstream proxies
+  splitter.rs            Splits/reassembles MTProto transport frames from WebSocket message boundaries
+  ws_client.rs           WebSocket client that dials Telegram DC endpoints (kwsN.web.telegram.org)
+  pool.rs                Pre-warmed pool of idle WebSocket connections per DC (cuts handshake latency)
+  check.rs               `--check` connectivity tester for CF domains and upstream MTProto proxies
+  default_domains.rs      Fetches + deobfuscates the community CF-proxy domain list from GitHub
+  runtime.rs              Shared runtime state (outbound connector, etc.) threaded through the app
+  outbound/               Outbound TCP connector: HTTP/SOCKS5(h) proxy support, NO_PROXY matching
+  default_domains/http.rs  Minimal HTTPS GET used only to fetch the default domain list
+
+tests/                   Integration tests (one file per subsystem, mirrors src/ module names)
+docs/                    CfProxy.md, CfWorker.md — setup guides for Cloudflare-based fallback routing
+```
+
+`src/lib.rs` re-exports the crate's internals so integration tests in `tests/` can exercise them
+directly; almost all logic lives in the library, `main.rs` is a thin binary wrapper.
+
+## Build, test, lint
+
+```bash
+cargo build                        # debug build
+cargo test                         # unit + integration tests (tests/*.rs)
+cargo clippy --all-targets         # CI runs this; keep it clean of new warnings
+cargo fmt                          # run before committing — CI does not auto-format
+cargo build --release              # CI also does a release build with LTO (see Cargo.toml profile)
+```
+
+CI (`.github/workflows/ci.yml`) additionally enforces that `Cargo.toml`'s `package.version` is
+strictly greater than the base branch's version on every PR, and matches the git tag on release
+builds. **Any change destined for `main` must bump the `version` field in `Cargo.toml`** (and let
+`cargo build` regenerate the matching line in `Cargo.lock`) — the CI job `release-version` fails
+the PR otherwise.
+
+## Conventions to follow
+
+- **CLI flags mirror env vars.** Every `#[arg(...)]` in `config.rs` has an `env = "TG_*"` fallback.
+  New flags should follow the same pattern so Docker/systemd deployments stay config-file-free.
+- **Module-level `//!` doc comments explain the *protocol/why*, not the *what*.** Look at the top
+  of `crypto.rs`, `faketls.rs`, `splitter.rs`, `pool.rs` for the expected level of detail — they
+  describe non-obvious protocol framing/timing reasons, not restate the code.
+- **All outbound TCP connections go through `src/outbound/`.** Direct WS, Cloudflare, Cloudflare
+  Worker, TCP fallback, `--check`, and the default-domain fetch all call into the shared outbound
+  connector so proxy/NO_PROXY behavior stays consistent. Don't open a raw `TcpStream::connect`
+  elsewhere.
+- **Integration tests are organized by subsystem**, one file per `src/` module area (e.g.
+  `tests/config.rs`, `tests/outbound.rs`, `tests/faketls.rs`). Add new tests to the matching file
+  rather than creating a new one per feature.
+- **No comments that restate code.** Only comment on non-obvious protocol constraints, timing
+  workarounds, or invariants — consistent with the existing style throughout `src/`.
+- Follow the general engineering discipline already in place in this repo: small, focused diffs;
+  don't add abstractions or config knobs beyond what's needed for the task at hand.
+
+## Gotchas specific to this codebase
+
+- The MTProto transport and the WebSocket transport have different framing guarantees — see
+  `splitter.rs`. Never assume one WebSocket message == one MTProto packet without going through
+  the splitter.
+- `--host` auto-detection (`Config::bind_host`/`Config::link_host` in `config.rs`) intentionally
+  keeps the bind address and the advertised `tg://` link address consistent. If you touch this
+  logic, verify both by actually starting the binary (`cargo run -- --port <N>`) and reading the
+  startup banner — a passing `cargo test` alone won't catch a bind/link mismatch a user would see.
+- FakeTLS (`0xee` secrets) affects both the inbound listener (`--listen-faketls-domain`) and
+  upstream MTProto proxies (`--mtproto-proxy` with an `ee`-prefixed secret) — they share
+  `faketls.rs` but are configured independently; don't conflate the two when making changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ tg-ws-proxy [OPTIONS]
 | Flag | Default | Description |
 |---|---|---|
 | `--port <PORT>` | `1443` | Listen port |
-| `--host <HOST>` | `127.0.0.1` | Listen address |
+| `--host <HOST>` | auto-detected | Listen address. Binds `0.0.0.0` if a LAN IP is detected (so it matches the auto-detected link IP below), otherwise `127.0.0.1` |
 | `--link-ip <IP>` | auto-detected | IP shown in the `tg://` link (see [Router deployment](#router-deployment)) |
 | `--secret <HEX>` | random | 32 hex-char MTProto secret (repeatable / comma-separated for per-user secrets) |
 | `--listen-faketls-domain <DOMAIN>` | — | Accept inbound clients with `ee` FakeTLS and advertise this SNI domain in the link |
@@ -468,16 +468,17 @@ warning — it will still start normally.
 
 ### Router deployment
 
-Run the proxy on your router with `--host 0.0.0.0` so it accepts connections
-from all LAN devices:
+Run the proxy on your router without `--host` (or with `--host 0.0.0.0`) so
+it accepts connections from all LAN devices:
 
 ```bash
-tg-ws-proxy --host 0.0.0.0 --port 1443
+tg-ws-proxy --port 1443
 ```
 
-When `--host 0.0.0.0` is used, the proxy **auto-detects** the router's LAN IP
-address and uses it in the generated `tg://` link, so you can share the same
-link with every device on your network.
+When no `--host` is given and a LAN IP can be auto-detected, the proxy binds
+`0.0.0.0` (all interfaces) and uses the detected LAN IP in the generated
+`tg://` link, so the link is actually reachable and you can share it with
+every device on your network.
 
 If auto-detection picks the wrong interface, override it explicitly:
 
@@ -485,9 +486,10 @@ If auto-detection picks the wrong interface, override it explicitly:
 tg-ws-proxy --host 0.0.0.0 --link-ip 192.168.1.1
 ```
 
-> **Note:** The default `--host 127.0.0.1` only accepts connections from the
+> **Note:** Passing `--host 127.0.0.1` explicitly restricts connections to the
 > machine running the proxy. Other devices on the network will not be able to
-> connect unless you change this to `0.0.0.0` (or the router's LAN IP).
+> connect unless you use `0.0.0.0` (or omit `--host` entirely) so it binds to
+> the router's LAN IP.
 
 ## Telegram Desktop Setup
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,8 +105,11 @@ pub struct Config {
     pub port: u16,
 
     /// Host / IP address to bind.
-    #[arg(long, default_value = "127.0.0.1", env = "TG_HOST")]
-    pub host: String,
+    /// When omitted, the proxy binds `0.0.0.0` if a LAN IP can be
+    /// auto-detected (so the address advertised in the proxy link is
+    /// actually reachable), otherwise it falls back to `127.0.0.1`.
+    #[arg(long, env = "TG_HOST")]
+    pub host: Option<String>,
 
     /// MTProto proxy secret(s) (32 hex chars each).
     /// Can be specified multiple times or as a comma-separated list.
@@ -531,26 +534,49 @@ impl Config {
         )
     }
 
+    /// The address the TCP listener actually binds to.
+    ///
+    /// Resolution order:
+    /// 1. `--host` if explicitly set — the user's choice is always respected.
+    /// 2. `0.0.0.0` (all interfaces) when no `--host` was given and a LAN IP
+    ///    can be auto-detected, so the address advertised by `link_host`
+    ///    below is actually reachable instead of only bindable on loopback.
+    /// 3. `127.0.0.1` as the final fallback (no LAN connectivity detected).
+    pub fn bind_host(&self) -> String {
+        if let Some(ref host) = self.host {
+            return host.clone();
+        }
+
+        if detect_lan_ip().is_some() {
+            "0.0.0.0".to_string()
+        } else {
+            "127.0.0.1".to_string()
+        }
+    }
+
     /// The hostname/IP to advertise in the generated `tg://proxy` link.
     ///
     /// Resolution order:
     /// 1. `--link-ip` if explicitly set.
-    /// 2. Auto-detected first non-loopback IPv4 address when `--host` is a
-    ///    wildcard (`0.0.0.0`) or loopback (`127.0.0.1` / `::1`).
-    /// 3. `--host` verbatim as the final fallback.
+    /// 2. Auto-detected first non-loopback IPv4 address when the bind
+    ///    address (see `bind_host`) is a wildcard (`0.0.0.0`) or loopback
+    ///    (`127.0.0.1` / `::1`).
+    /// 3. The bind address verbatim as the final fallback.
     pub fn link_host(&self) -> String {
         if let Some(ref ip) = self.link_ip {
             return ip.clone();
         }
 
+        let bind_host = self.bind_host();
+
         // Auto-detect when the bind address is not directly reachable by
         // remote clients (wildcard or loopback).
-        let bind_is_local = matches!(self.host.as_str(), "0.0.0.0" | "::" | "127.0.0.1" | "::1");
+        let bind_is_local = matches!(bind_host.as_str(), "0.0.0.0" | "::" | "127.0.0.1" | "::1");
         if bind_is_local && let Some(lan_ip) = detect_lan_ip() {
             return lan_ip;
         }
 
-        self.host.clone()
+        bind_host
     }
 
     /// Socket buffer size in bytes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,8 @@ async fn main() {
     }
 
     // ── Bind the server socket ────────────────────────────────────────────
-    let addr: SocketAddr = format!("{}:{}", config.host, config.port)
+    let bind_host = config.bind_host();
+    let addr: SocketAddr = format!("{}:{}", bind_host, config.port)
         .parse()
         .expect("invalid listen address");
 
@@ -195,8 +196,11 @@ async fn main() {
     );
 
     info!("{}", "=".repeat(60));
-    info!("  Telegram MTProto WS Bridge Proxy  (tg-ws-proxy-rs)");
-    info!("  Listening on   {}:{}", config.host, config.port);
+    info!(
+        "  Telegram MTProto WS Bridge Proxy  (tg-ws-proxy-rs v{})",
+        env!("CARGO_PKG_VERSION")
+    );
+    info!("  Listening on   {}:{}", bind_host, config.port);
     info!("  Secret:        {}", secret);
     if let Some(domain) = config.listen_faketls_domain() {
         info!("  Inbound mode:   FakeTLS ee (SNI: {})", domain);
@@ -264,18 +268,18 @@ async fn main() {
         }
     }
 
-    if link_host != config.host {
+    if link_host != bind_host {
         info!(
             "  ℹ  Link uses auto-detected IP {}. \
              Use --link-ip <IP> to override.",
             link_host
         );
-    } else if matches!(config.host.as_str(), "127.0.0.1" | "::1") {
+    } else if matches!(bind_host.as_str(), "127.0.0.1" | "::1") {
         warn!(
             "  ⚠  Link shows {} — only the local machine can use this link. \
              Run with --host 0.0.0.0 (or --link-ip <router-LAN-IP>) \
              so other devices on the network can connect.",
-            config.host
+            bind_host
         );
     }
     info!("{}", "=".repeat(60));

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -93,6 +93,34 @@ fn cf_worker_domains_accept_multiple_values_and_normalize() {
 }
 
 #[test]
+fn default_host_binds_and_links_to_the_same_address() {
+    // Regression test for https://github.com/valnesfjord/tg-ws-proxy-rs/issues/82:
+    // without --host, the listener must bind to whatever address link_host()
+    // advertises (or 127.0.0.1 if no LAN IP is detectable), never a mismatch
+    // like binding 127.0.0.1 while advertising a LAN IP that isn't reachable.
+    let cfg = Config::try_parse_from(["tg-ws-proxy"]).unwrap();
+
+    let bind_host = cfg.bind_host();
+    let link_host = cfg.link_host();
+
+    if bind_host == "0.0.0.0" {
+        // A LAN IP was detected: the link must show that concrete address,
+        // and 0.0.0.0 actually listens on it (unlike 127.0.0.1 before this fix).
+        assert_ne!(link_host, "0.0.0.0");
+    } else {
+        // No LAN connectivity: both must fall back to loopback consistently.
+        assert_eq!(bind_host, "127.0.0.1");
+        assert_eq!(link_host, "127.0.0.1");
+    }
+}
+
+#[test]
+fn explicit_host_is_respected_for_binding() {
+    let cfg = Config::try_parse_from(["tg-ws-proxy", "--host", "127.0.0.1"]).unwrap();
+    assert_eq!(cfg.bind_host(), "127.0.0.1");
+}
+
+#[test]
 fn cf_worker_domains_accept_repeated_flags_including_alias() {
     let cfg = Config::try_parse_from([
         "tg-ws-proxy",


### PR DESCRIPTION
## Summary
- `Config::bind_host()` now binds `0.0.0.0` when `--host` is omitted and a LAN IP can be auto-detected, so the address advertised in the `tg://` link (`link_host()`) is actually reachable instead of only bindable on loopback. Explicit `--host` is still respected exactly as before.
- Startup banner now prints the crate version (`tg-ws-proxy-rs vX.Y.Z`), addressing the secondary request in the issue.
- Added `AGENTS.md` documenting the project layout and conventions for coding agents.
- Bumped `Cargo.toml`/`Cargo.lock` to 1.6.3 (required by CI's version-bump check).

Fixes #82

## Test plan
- [x] `cargo test` — all existing + new tests pass
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt`
- [x] Manually ran the binary with no `--host` and confirmed it binds `0.0.0.0` while the link shows the detected LAN IP
- [x] Manually ran with `--host 127.0.0.1` and confirmed explicit choice is still honored (with the existing warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)