### PR TITLE
feat: port domain-fronting fallback from upstream (issue #81)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ tg-ws-proxy [OPTIONS]
 | `--default-domains` | off | Fetch and use the built-in CF proxy domain list from GitHub (no Cloudflare setup needed, see [Default domains](#default-domains)) |
 | `--cf-priority` | off | Try CF proxy **before** direct WS for all DCs (see [CF Proxy](#cloudflare-proxy)) |
 | `--cf-balance` | off | Round-robin load balance across multiple `--cf-domain` and `--cf-worker-domain` values (see [CF Proxy](#cloudflare-proxy)) |
+| `--fronting-domain <DOMAIN>` | off | Domain-fronting fallback SNI, e.g. `sprinthost.ru` (see [Domain fronting](#domain-fronting)) |
+| `--fronting-cooldown <SECS>` | `1800` | How long the fronting fallback stays active after it last succeeded |
 | `--max-connections <N>` | auto | Max concurrent client connections (auto-computed from `ulimit -n`) |
 | `--mtproto-proxy <HOST:PORT:SECRET>` | — | Upstream MTProto proxy fallback (repeatable) |
 | `--outbound-proxy <URL>` | — | Proxy for all outgoing connections: `http://`, `socks5://`, or `socks5h://`; `https://` proxy URLs are not supported |
@@ -119,7 +121,8 @@ Every flag has a matching environment variable (`TG_PORT`, `TG_HOST`,
 `TG_SECRET`, `TG_BUF_KB`, `TG_POOL_SIZE`, `TG_MAX_CONNECTIONS`, `TG_QUIET`,
 `TG_VERBOSE`, `TG_SKIP_TLS_VERIFY`, `TG_LINK_IP`, `TG_LISTEN_FAKETLS_DOMAIN`, `TG_MTPROTO_PROXY`,
 `TG_LOG_FILE`, `TG_CF_DOMAIN`, `TG_CF_WORKER_DOMAIN`, `TG_CF_PRIORITY`,
-`TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`, `TG_OUTBOUND_PROXY`, `TG_NO_OUTBOUND_PROXY`, `TG_NO_PROXY`).
+`TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`, `TG_OUTBOUND_PROXY`, `TG_NO_OUTBOUND_PROXY`, `TG_NO_PROXY`,
+`TG_FRONTING_DOMAIN`, `TG_FRONTING_COOLDOWN`).
 When `TG_OUTBOUND_PROXY` is not set, standard `HTTPS_PROXY`, `ALL_PROXY`,
 `HTTP_PROXY` and `NO_PROXY` environment variables are also honored. `https://`
 proxy URLs are skipped when discovered from the standard environment if a later
@@ -428,6 +431,32 @@ For DCs with a configured direct WebSocket target, direct WS is tried first and
 the Worker is used only after that path fails. For DCs without a direct WS
 target, the Worker is tried before the regular Cloudflare proxy/default
 domains and the remaining fallbacks.
+
+### Domain fronting
+
+If direct WebSocket connections to Telegram keep timing out — a common sign
+of SNI-based DPI blocking — the proxy can fall back to **domain fronting**:
+presenting an unrelated, presumably-unblocked domain as the TLS SNI while
+still connecting to the real Telegram DC IP and using the real DC domain as
+the HTTP `Host`. DPI that filters by SNI sees the fronted name; the actual
+(TLS-encrypted) request still reaches Telegram normally.
+
+```bash
+tg-ws-proxy --fronting-domain sprinthost.ru
+```
+
+Disabled unless `--fronting-domain` is set. Once a fronted connection
+succeeds, the fallback stays active (including for background connection-pool
+refills) for `--fronting-cooldown` seconds (default 1800 = 30 min), so the
+proxy doesn't keep re-probing the likely-still-blocked direct path on every
+new connection.
+
+> **Note:** TLS certificate verification is unconditionally skipped on
+> connections using this fallback, regardless of
+> `--danger-accept-invalid-certs` — the real Telegram certificate can never
+> match a fronted SNI, so hostname verification would always fail. This is
+> inherent to the technique, not a bug, and only applies to the direct-WS
+> fallback path (not CF proxy/Worker connections).
 
 ### Default domains
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -327,6 +327,32 @@ pub struct Config {
     )]
     pub cf_fail_cooldown: u64,
 
+    /// Domain to present as the TLS SNI for the domain-fronting fallback,
+    /// used when direct WebSocket connects to a DC keep timing out (a sign
+    /// of SNI-based DPI blocking). The real DC IP and `Host` are still used —
+    /// only the SNI is swapped for this unrelated, presumably-unblocked
+    /// domain, e.g. `sprinthost.ru` (the value upstream tg-ws-proxy uses).
+    ///
+    /// Disabled unless set. TLS certificate verification is unconditionally
+    /// skipped on connections using this fallback: the real Telegram
+    /// certificate can never match a fronted SNI, so hostname verification
+    /// would always fail — this is inherent to the technique, not a bug.
+    ///
+    /// Once a fronted connection succeeds, the fallback stays active for
+    /// `--fronting-cooldown` seconds so new connections (including
+    /// background pool refills) keep using it.
+    #[arg(long = "fronting-domain", env = "TG_FRONTING_DOMAIN")]
+    pub fronting_domain: Option<String>,
+
+    /// Seconds to keep the domain-fronting fallback active after it last
+    /// succeeded, before returning to normal direct WebSocket attempts.
+    #[arg(
+        long = "fronting-cooldown",
+        default_value = "1800",
+        env = "TG_FRONTING_COOLDOWN"
+    )]
+    pub fronting_cooldown: u64,
+
     /// Maximum age of a pooled WebSocket connection in seconds.
     /// Connections older than this are discarded and re-established.
     #[arg(long = "pool-max-age", default_value = "55", env = "TG_POOL_MAX_AGE")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,10 @@ async fn main() {
             std::process::exit(2);
         }
     };
-    let runtime = Arc::new(Runtime::new(outbound));
+    let runtime = Arc::new(Runtime::new(outbound).with_fronting(
+        config.fronting_domain.clone(),
+        Duration::from_secs(config.fronting_cooldown),
+    ));
 
     // ── Logging ──────────────────────────────────────────────────────────
     let log_level = if config.quiet {
@@ -248,6 +251,13 @@ async fn main() {
 
     if let Some(summary) = runtime.outbound().summary() {
         info!("  Outbound proxy: {}", summary);
+    }
+
+    if let Some(domain) = runtime.fronting_domain() {
+        info!(
+            "  Domain fronting: enabled (SNI {}, sticky for {}s after success)",
+            domain, config.fronting_cooldown
+        );
     }
 
     info!(

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -240,6 +240,15 @@ impl WsPool {
         let mut results = Vec::new();
         // Limit pool fill timeout to avoid blocking for too long.
         let timeout = Duration::from_secs(8);
+        // While the domain-fronting fallback is in its sticky window, warm the
+        // pool with fronted connections too — otherwise a pool hit would hand
+        // a client a connection that never had to front in the first place,
+        // defeating the point of staying "sticky".
+        let fronting_domain = self
+            .runtime
+            .fronting_active()
+            .then(|| self.runtime.fronting_domain())
+            .flatten();
 
         for _ in 0..count {
             match connect_ws_for_dc_with_outbound(
@@ -249,11 +258,12 @@ impl WsPool {
                 skip_tls,
                 timeout,
                 self.runtime.outbound(),
+                fronting_domain,
             )
             .await
             {
-                (Some(ws), _) => results.push(ws),
-                (None, _) => {
+                (Some(ws), _, _) => results.push(ws),
+                (None, _, _) => {
                     warn!(
                         "pool: failed to pre-connect DC{}{}",
                         dc,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -821,27 +821,86 @@ pub async fn handle_client_with_runtime(
         ws
     } else {
         // ── Step 6b: fresh WebSocket connect ────────────────────────────
-        let (ws_opt, all_redirects) = connect_ws_for_dc_with_outbound(
+        // While the domain-fronting fallback is in its sticky window, skip
+        // straight to a fronted attempt instead of the normal per-domain
+        // loop — matching upstream's "stay fronted while it keeps working"
+        // behavior instead of re-probing the (likely still-blocked) direct
+        // path on every connection.
+        let sticky_fronting_domain = runtime
+            .fronting_active()
+            .then(|| runtime.fronting_domain())
+            .flatten();
+
+        let (mut ws_opt, all_redirects, timed_out) = connect_ws_for_dc_with_outbound(
             &target_ip,
             ws_dc,
             is_media,
             skip_tls,
             ws_timeout,
             runtime.outbound(),
+            sticky_fronting_domain,
         )
         .await;
 
-        match ws_opt {
-            Some(ws) => {
-                clear_dc_cooldown(dc_id, is_media);
-
+        if let Some(domain) = sticky_fronting_domain {
+            if ws_opt.is_some() {
+                runtime.activate_fronting();
                 info!(
-                    "[{}] DC{}{} → WS connected via {}",
-                    label, dc_id, media_tag, target_ip
+                    "[{}] DC{}{} → fronting connected (SNI {})",
+                    label, dc_id, media_tag, domain
                 );
-
-                ws
+            } else {
+                runtime.deactivate_fronting();
+                warn!(
+                    "[{}] DC{}{} fronting (sticky) failed, falling back",
+                    label, dc_id, media_tag
+                );
             }
+        } else if ws_opt.is_some() {
+            clear_dc_cooldown(dc_id, is_media);
+
+            info!(
+                "[{}] DC{}{} → WS connected via {}",
+                label, dc_id, media_tag, target_ip
+            );
+        } else if timed_out && let Some(domain) = runtime.fronting_domain() {
+            // Reactive fronting: the normal (non-fronted) attempt above
+            // timed out — a sign of SNI-based DPI blocking — so try once
+            // more with the fronted SNI before falling back to cooldown +
+            // CF/upstream/TCP.
+            info!(
+                "[{}] DC{}{} WS timed out → trying fronting (SNI {})",
+                label, dc_id, media_tag, domain
+            );
+
+            let (front_opt, _all_redirects, _timed_out) = connect_ws_for_dc_with_outbound(
+                &target_ip,
+                ws_dc,
+                is_media,
+                skip_tls,
+                ws_timeout,
+                runtime.outbound(),
+                Some(domain),
+            )
+            .await;
+
+            if front_opt.is_some() {
+                runtime.activate_fronting();
+                info!(
+                    "[{}] DC{}{} → fronting connected (SNI {})",
+                    label, dc_id, media_tag, domain
+                );
+            } else {
+                warn!(
+                    "[{}] DC{}{} fronting fallback failed",
+                    label, dc_id, media_tag
+                );
+            }
+            ws_opt = front_opt;
+        }
+
+        match ws_opt {
+            Some(ws) => ws,
             None => {
                 // WS failed — apply cooldown and try CF proxy, upstream proxies, or TCP fallback.
                 if all_redirects {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::sync::Mutex as StdMutex;
+use std::time::{Duration, Instant};
 
 use crate::config::{default_dc_ips, default_dc_overrides};
 use crate::outbound::OutboundConnector;
@@ -7,6 +9,15 @@ pub struct Runtime {
     outbound: OutboundConnector,
     dc_overrides: HashMap<u32, u32>,
     dc_fallback_ips: HashMap<u32, String>,
+    /// Domain-fronting SNI, when enabled via `--fronting-domain`. `None` means
+    /// the fallback is disabled entirely (the default).
+    fronting_domain: Option<String>,
+    /// How long the fronting fallback stays "sticky" after last succeeding.
+    fronting_cooldown: Duration,
+    /// Shared with `pool.rs`'s background refill (unlike the per-DC cooldowns
+    /// in `proxy.rs`, which only that module's own fallback logic needs),
+    /// which is why this lives on `Runtime` instead of a `proxy.rs` static.
+    fronting_until: StdMutex<Option<Instant>>,
 }
 
 impl Runtime {
@@ -15,7 +26,17 @@ impl Runtime {
             outbound,
             dc_overrides: default_dc_overrides(),
             dc_fallback_ips: default_dc_ips(),
+            fronting_domain: None,
+            fronting_cooldown: Duration::from_secs(1800),
+            fronting_until: StdMutex::new(None),
         }
+    }
+
+    /// Configure the domain-fronting fallback. `domain: None` keeps it disabled.
+    pub fn with_fronting(mut self, domain: Option<String>, cooldown: Duration) -> Self {
+        self.fronting_domain = domain;
+        self.fronting_cooldown = cooldown;
+        self
     }
 
     pub fn outbound(&self) -> &OutboundConnector {
@@ -28,5 +49,26 @@ impl Runtime {
 
     pub fn fallback_ip(&self, dc: u32) -> Option<&str> {
         self.dc_fallback_ips.get(&dc).map(String::as_str)
+    }
+
+    /// The configured fronting SNI, if the fallback is enabled.
+    pub fn fronting_domain(&self) -> Option<&str> {
+        self.fronting_domain.as_deref()
+    }
+
+    /// Whether the fronting fallback is currently in its sticky window.
+    pub fn fronting_active(&self) -> bool {
+        matches!(*self.fronting_until.lock().unwrap(), Some(until) if Instant::now() < until)
+    }
+
+    /// Mark the fronting fallback as active for another `fronting_cooldown`
+    /// from now (called after a successful fronted connection).
+    pub fn activate_fronting(&self) {
+        *self.fronting_until.lock().unwrap() = Some(Instant::now() + self.fronting_cooldown);
+    }
+
+    /// Clear the sticky window (called after a fronted connection fails).
+    pub fn deactivate_fronting(&self) {
+        *self.fronting_until.lock().unwrap() = None;
     }
 }

--- a/src/ws_client.rs
+++ b/src/ws_client.rs
@@ -31,6 +31,7 @@ use rustls::{
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
     Connector, MaybeTlsStream, WebSocketStream, client_async_tls_with_config,
+    client_async_with_config,
     tungstenite::{client::IntoClientRequest, http::HeaderValue},
 };
 use tracing::{debug, warn};
@@ -78,6 +79,10 @@ pub enum WsConnectResult {
     Redirect(u16),
     /// Any other non-101 status code or transport error.
     Failed(String),
+    /// The connection attempt did not complete within the given timeout.
+    /// Kept distinct from `Failed` so callers can trigger timeout-specific
+    /// fallbacks (e.g. domain fronting) without string-matching error text.
+    TimedOut,
 }
 
 /// Try to establish a WebSocket connection to one Telegram DC domain.
@@ -96,18 +101,24 @@ pub async fn connect_ws(
         skip_tls_verify,
         timeout,
         &OutboundConnector::direct(),
+        None,
     )
     .await
 }
 
 /// Same as [`connect_ws`], but routes the TCP connection through the supplied
 /// outbound connector.
+///
+/// `sni_override`, when set, presents that hostname as the TLS SNI instead of
+/// `domain` while still using `domain` as the HTTP `Host` — see
+/// [`connect_ws_with_path`] for why and how.
 pub async fn connect_ws_with_outbound(
     ip: &str,
     domain: &str,
     skip_tls_verify: bool,
     timeout: Duration,
     outbound: &OutboundConnector,
+    sni_override: Option<&str>,
 ) -> WsConnectResult {
     connect_ws_with_path(
         ip,
@@ -117,10 +128,22 @@ pub async fn connect_ws_with_outbound(
         skip_tls_verify,
         timeout,
         outbound,
+        sni_override,
     )
     .await
 }
 
+/// Connect to `ip:443` and perform the WebSocket upgrade to `wss://{domain}{path}`.
+///
+/// Normally the TLS SNI is `domain` (matching the `Host` header). When
+/// `sni_override` is set, the TLS handshake instead presents that unrelated
+/// hostname as SNI — domain fronting — while the HTTP request still targets
+/// `domain` as `Host`. DPI that filters by SNI sees the fronted name; the
+/// actual (TLS-encrypted) request still reaches the real `domain` normally.
+/// Because the server's real certificate can never match a fronted SNI,
+/// certificate verification is unconditionally skipped in that case,
+/// regardless of `skip_tls_verify`.
+#[allow(clippy::too_many_arguments)]
 async fn connect_ws_with_path(
     ip: &str,
     domain: &str,
@@ -129,6 +152,7 @@ async fn connect_ws_with_path(
     skip_tls_verify: bool,
     timeout: Duration,
     outbound: &OutboundConnector,
+    sni_override: Option<&str>,
 ) -> WsConnectResult {
     // ── TCP connection to the configured IP ──────────────────────────────
     let tcp = match outbound.connect(ip, 443, timeout).await {
@@ -167,13 +191,10 @@ async fn connect_ws_with_path(
         );
     }
 
-    // ── TLS connector ────────────────────────────────────────────────────
-    let connector = build_tls_connector(skip_tls_verify);
-
-    // ── WebSocket handshake over the existing TCP stream ─────────────────
+    // ── TLS handshake + WebSocket upgrade ─────────────────────────────────
     let result = tokio::time::timeout(
         timeout,
-        client_async_tls_with_config(request, tcp, None, Some(connector)),
+        tls_handshake_and_upgrade(tcp, request, skip_tls_verify, sni_override),
     )
     .await;
 
@@ -204,7 +225,42 @@ async fn connect_ws_with_path(
                 WsConnectResult::Failed(e.to_string())
             }
         }
-        Err(_) => WsConnectResult::Failed("WebSocket handshake timed out".into()),
+        Err(_) => WsConnectResult::TimedOut,
+    }
+}
+
+/// Perform the TLS handshake (with optional SNI override) and the WebSocket
+/// upgrade over an already-connected TCP stream.
+///
+/// Split out from `connect_ws_with_path` so it can be exercised in tests
+/// against a stream connected to an arbitrary local port — the public
+/// connect functions always dial `:443`, Telegram's real WS port.
+async fn tls_handshake_and_upgrade<R>(
+    tcp: TcpStream,
+    request: R,
+    skip_tls_verify: bool,
+    sni_override: Option<&str>,
+) -> Result<(TgWsStream, tungstenite::handshake::client::Response), WsError>
+where
+    R: IntoClientRequest + Unpin,
+{
+    if let Some(sni) = sni_override {
+        // Domain fronting: TLS SNI = `sni`, Host stays whatever `request`
+        // already carries. Manual TLS is required here because
+        // `client_async_tls_with_config` always derives the SNI from the
+        // request's own host, with no way to override it.
+        let server_name = ServerName::try_from(sni)
+            .map_err(|_| WsError::Url(tungstenite::error::UrlError::NoHostName))?
+            .to_owned();
+        let tls_connector = tokio_rustls::TlsConnector::from(Arc::new(no_verify_rustls_config()));
+        let tls_stream = tls_connector
+            .connect(server_name, tcp)
+            .await
+            .map_err(WsError::Io)?;
+        client_async_with_config(request, MaybeTlsStream::Rustls(tls_stream), None).await
+    } else {
+        let connector = build_tls_connector(skip_tls_verify);
+        client_async_tls_with_config(request, tcp, None, Some(connector)).await
     }
 }
 
@@ -251,19 +307,27 @@ pub async fn connect_ws_for_dc(
     skip_tls_verify: bool,
     timeout: Duration,
 ) -> (Option<TgWsStream>, bool) {
-    connect_ws_for_dc_with_outbound(
+    let (ws, all_redirects, _timed_out) = connect_ws_for_dc_with_outbound(
         ip,
         dc,
         is_media,
         skip_tls_verify,
         timeout,
         &OutboundConnector::direct(),
+        None,
     )
-    .await
+    .await;
+    (ws, all_redirects)
 }
 
 /// Same as [`connect_ws_for_dc`], but routes each TCP connection through the
 /// supplied outbound connector.
+///
+/// `sni_override` is forwarded to every domain attempt — see
+/// [`connect_ws_with_path`] for what it does. Returns
+/// `(stream, all_redirects, any_timed_out)`, where `any_timed_out` is `true`
+/// when at least one domain attempt hit the connect timeout (as opposed to a
+/// redirect or other failure) — used to trigger the domain-fronting fallback.
 pub async fn connect_ws_for_dc_with_outbound(
     ip: &str,
     dc: u32,
@@ -271,9 +335,11 @@ pub async fn connect_ws_for_dc_with_outbound(
     skip_tls_verify: bool,
     timeout: Duration,
     outbound: &OutboundConnector,
-) -> (Option<TgWsStream>, bool) {
+    sni_override: Option<&str>,
+) -> (Option<TgWsStream>, bool, bool) {
     let domains = ws_domains(dc, is_media);
     let mut all_redirects = true;
+    let mut any_timed_out = false;
 
     for domain in &domains {
         debug!(
@@ -284,9 +350,11 @@ pub async fn connect_ws_for_dc_with_outbound(
             ip
         );
 
-        match connect_ws_with_outbound(ip, domain, skip_tls_verify, timeout, outbound).await {
+        match connect_ws_with_outbound(ip, domain, skip_tls_verify, timeout, outbound, sni_override)
+            .await
+        {
             WsConnectResult::Connected(ws) => {
-                return (Some(ws), false);
+                return (Some(ws), false, false);
             }
             WsConnectResult::Redirect(code) => {
                 warn!(
@@ -309,10 +377,21 @@ pub async fn connect_ws_for_dc_with_outbound(
 
                 all_redirects = false; // a real failure, not just a redirect
             }
+            WsConnectResult::TimedOut => {
+                warn!(
+                    "WS DC{}{} timed out on {}",
+                    dc,
+                    if is_media { "m" } else { "" },
+                    domain
+                );
+
+                all_redirects = false;
+                any_timed_out = true;
+            }
         }
     }
 
-    (None, all_redirects)
+    (None, all_redirects, any_timed_out)
 }
 
 /// WebSocket domains for a given DC when routing through one or more
@@ -407,7 +486,9 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
 
         // Pass the CF domain as the TCP host so that Tokio's DNS resolution
         // returns Cloudflare's anycast IP rather than Telegram's DC IP.
-        match connect_ws_with_outbound(domain, domain, skip_tls_verify, timeout, outbound).await {
+        match connect_ws_with_outbound(domain, domain, skip_tls_verify, timeout, outbound, None)
+            .await
+        {
             WsConnectResult::Connected(ws) => {
                 return (Some(ws), false);
             }
@@ -440,6 +521,7 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
                         skip_tls_verify,
                         timeout,
                         outbound,
+                        None,
                     )
                     .await
                     {
@@ -465,6 +547,15 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
                             );
                             all_redirects = false;
                         }
+                        WsConnectResult::TimedOut => {
+                            warn!(
+                                "CF WS DC{}{} timed out on {}",
+                                dc,
+                                if is_media { "m" } else { "" },
+                                fallback
+                            );
+                            all_redirects = false;
+                        }
                     }
                 } else {
                     warn!(
@@ -476,6 +567,15 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
                     );
                     all_redirects = false;
                 }
+            }
+            WsConnectResult::TimedOut => {
+                warn!(
+                    "CF WS DC{}{} timed out on {}",
+                    dc,
+                    if is_media { "m" } else { "" },
+                    domain
+                );
+                all_redirects = false;
             }
         }
     }
@@ -537,6 +637,7 @@ pub async fn connect_cf_worker_ws_for_dc_with_outbound(
         skip_tls_verify,
         timeout,
         outbound,
+        None,
     )
     .await
     {
@@ -558,6 +659,15 @@ pub async fn connect_cf_worker_ws_for_dc_with_outbound(
                 if is_media { "m" } else { "" },
                 worker_domain,
                 reason
+            );
+            None
+        }
+        WsConnectResult::TimedOut => {
+            warn!(
+                "CF Worker DC{}{} timed out on {}",
+                dc,
+                if is_media { "m" } else { "" },
+                worker_domain
             );
             None
         }
@@ -609,11 +719,19 @@ fn build_default_rustls_config() -> rustls::ClientConfig {
 }
 
 fn build_no_verify_connector() -> Connector {
-    let config = rustls::ClientConfig::builder()
+    Connector::Rustls(Arc::new(no_verify_rustls_config()))
+}
+
+/// A `rustls::ClientConfig` that accepts any certificate, regardless of
+/// hostname or trust chain. Shared by `--danger-accept-invalid-certs` and by
+/// the domain-fronting path, which *always* needs it: the real certificate
+/// presented by Telegram can never match a fronted (spoofed) SNI hostname, so
+/// hostname verification would fail even for an otherwise-legitimate server.
+fn no_verify_rustls_config() -> rustls::ClientConfig {
+    rustls::ClientConfig::builder()
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(NoVerifier))
-        .with_no_client_auth();
-    Connector::Rustls(Arc::new(config))
+        .with_no_client_auth()
 }
 
 /// Build a root certificate store from the bundled WebPKI roots.
@@ -674,3 +792,6 @@ impl ServerCertVerifier for NoVerifier {
         ]
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/ws_client/tests.rs
+++ b/src/ws_client/tests.rs
@@ -1,0 +1,139 @@
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::accept_hdr_async;
+
+use super::*;
+
+fn install_rustls_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn test_certificate(domain: &str) -> (CertificateDer<'static>, PrivateKeyDer<'static>) {
+    let cert = rcgen::generate_simple_self_signed(vec![domain.to_string()]).unwrap();
+    let cert_der = CertificateDer::from(cert.serialize_der().unwrap());
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(cert.serialize_private_key_der()));
+    (cert_der, key_der)
+}
+
+/// Regression test for the domain-fronting fallback (issue #81): the TLS SNI
+/// sent on the wire must be the fronted domain, while the WebSocket upgrade's
+/// `Host` header must still be the real one — and the handshake must succeed
+/// even though the server's certificate only covers the real domain (proving
+/// certificate verification is skipped for fronted connections, since a real
+/// cert can never match a spoofed SNI).
+#[tokio::test]
+async fn sni_override_presents_fronted_sni_but_keeps_real_host() {
+    install_rustls_provider();
+
+    let real_domain = "real.example.test";
+    let fronted_sni = "fronted.example.test";
+
+    let (cert, key) = test_certificate(real_domain);
+    let observed_sni: Arc<StdMutex<Option<String>>> = Arc::new(StdMutex::new(None));
+    let observed_host: Arc<StdMutex<Option<String>>> = Arc::new(StdMutex::new(None));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_sni = Arc::clone(&observed_sni);
+    let server_host = Arc::clone(&observed_host);
+    let server_task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+
+        // Peek at the ClientHello's SNI before picking a server config —
+        // this is the only way to observe what SNI the client actually sent
+        // on the wire.
+        let acceptor =
+            tokio_rustls::LazyConfigAcceptor::new(rustls::server::Acceptor::default(), stream);
+        tokio::pin!(acceptor);
+        let start = acceptor.as_mut().await.unwrap();
+        *server_sni.lock().unwrap() = start.client_hello().server_name().map(str::to_string);
+
+        let config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .unwrap();
+        let tls_stream = start.into_stream(Arc::new(config)).await.unwrap();
+
+        accept_hdr_async(
+            tls_stream,
+            move |req: &tungstenite::handshake::server::Request, resp| {
+                let host = req
+                    .headers()
+                    .get("Host")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string);
+                *server_host.lock().unwrap() = host;
+                Ok(resp)
+            },
+        )
+        .await
+        .unwrap();
+    });
+
+    let tcp = TcpStream::connect(addr).await.unwrap();
+    let request = format!("wss://{real_domain}/apiws")
+        .into_client_request()
+        .unwrap();
+
+    let (ws, response) = tls_handshake_and_upgrade(tcp, request, false, Some(fronted_sni))
+        .await
+        .expect("fronted handshake should succeed even though the cert doesn't match the SNI");
+    assert_eq!(response.status().as_u16(), 101);
+    drop(ws);
+
+    tokio::time::timeout(Duration::from_secs(2), server_task)
+        .await
+        .expect("server task timed out")
+        .expect("server task panicked");
+
+    assert_eq!(observed_sni.lock().unwrap().as_deref(), Some(fronted_sni));
+    assert_eq!(observed_host.lock().unwrap().as_deref(), Some(real_domain));
+}
+
+/// Without an override, SNI and Host both stay the real domain (unchanged
+/// existing behavior) — and, unlike the fronted path, this goes through the
+/// normal certificate-verified connector, so it must fail against a
+/// self-signed cert that isn't in the trust store.
+#[tokio::test]
+async fn no_sni_override_uses_domain_for_both_and_verifies_the_certificate() {
+    install_rustls_provider();
+
+    let real_domain = "real.example.test";
+    let (cert, key) = test_certificate(real_domain);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
+        // The client is expected to abort during the TLS handshake because
+        // it doesn't trust this self-signed cert, so the accept here may
+        // legitimately fail — that's the point of the assertion below.
+        let _ = acceptor.accept(stream).await;
+    });
+
+    let tcp = TcpStream::connect(addr).await.unwrap();
+    let request = format!("wss://{real_domain}/apiws")
+        .into_client_request()
+        .unwrap();
+
+    let result = tls_handshake_and_upgrade(tcp, request, false, None).await;
+    assert!(
+        result.is_err(),
+        "expected certificate verification to reject the self-signed cert"
+    );
+
+    tokio::time::timeout(Duration::from_secs(2), server_task)
+        .await
+        .expect("server task timed out")
+        .ok();
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -121,6 +121,29 @@ fn explicit_host_is_respected_for_binding() {
 }
 
 #[test]
+fn fronting_domain_is_disabled_by_default() {
+    let cfg = Config::try_parse_from(["tg-ws-proxy"]).unwrap();
+
+    assert_eq!(cfg.fronting_domain, None);
+    assert_eq!(cfg.fronting_cooldown, 1800);
+}
+
+#[test]
+fn fronting_flags_parse() {
+    let cfg = Config::try_parse_from([
+        "tg-ws-proxy",
+        "--fronting-domain",
+        "sprinthost.ru",
+        "--fronting-cooldown",
+        "60",
+    ])
+    .unwrap();
+
+    assert_eq!(cfg.fronting_domain.as_deref(), Some("sprinthost.ru"));
+    assert_eq!(cfg.fronting_cooldown, 60);
+}
+
+#[test]
 fn cf_worker_domains_accept_repeated_flags_including_alias() {
     let cfg = Config::try_parse_from([
         "tg-ws-proxy",

--- a/tests/outbound_call_sites.rs
+++ b/tests/outbound_call_sites.rs
@@ -28,6 +28,7 @@ async fn ws_client_connects_through_outbound_proxy() {
         false,
         Duration::from_secs(2),
         &outbound,
+        None,
     )
     .await;
 
@@ -49,13 +50,14 @@ async fn telegram_ws_dc_connector_uses_outbound_proxy() {
     let outbound =
         OutboundConnector::from_config(Some(&format!("http://{proxy_addr}")), None, false).unwrap();
 
-    let (ws, all_redirects) = connect_ws_for_dc_with_outbound(
+    let (ws, all_redirects, _timed_out) = connect_ws_for_dc_with_outbound(
         "203.0.113.10",
         2,
         false,
         false,
         Duration::from_secs(2),
         &outbound,
+        None,
     )
     .await;
 

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use tg_ws_proxy_rs::outbound::OutboundConnector;
+use tg_ws_proxy_rs::runtime::Runtime;
+
+#[test]
+fn fronting_disabled_by_default() {
+    let runtime = Runtime::new(OutboundConnector::direct());
+
+    assert_eq!(runtime.fronting_domain(), None);
+    assert!(!runtime.fronting_active());
+}
+
+#[test]
+fn fronting_disabled_without_a_domain_even_if_activated() {
+    // `with_fronting(None, ..)` must keep the fallback off regardless of
+    // what activate_fronting() does — callers gate on fronting_domain()
+    // being Some before ever calling activate_fronting(), but the invariant
+    // should hold even if that changes.
+    let runtime =
+        Runtime::new(OutboundConnector::direct()).with_fronting(None, Duration::from_secs(1800));
+
+    assert_eq!(runtime.fronting_domain(), None);
+    assert!(!runtime.fronting_active());
+}
+
+#[test]
+fn activate_fronting_makes_it_active_until_cooldown_expires() {
+    let runtime = Runtime::new(OutboundConnector::direct())
+        .with_fronting(Some("sprinthost.ru".to_string()), Duration::from_secs(1800));
+
+    assert!(!runtime.fronting_active());
+
+    runtime.activate_fronting();
+
+    assert!(runtime.fronting_active());
+    assert_eq!(runtime.fronting_domain(), Some("sprinthost.ru"));
+}
+
+#[test]
+fn deactivate_fronting_clears_the_sticky_window() {
+    let runtime = Runtime::new(OutboundConnector::direct())
+        .with_fronting(Some("sprinthost.ru".to_string()), Duration::from_secs(1800));
+
+    runtime.activate_fronting();
+    assert!(runtime.fronting_active());
+
+    runtime.deactivate_fronting();
+    assert!(!runtime.fronting_active());
+    // The configured domain itself is unaffected by deactivation — only the
+    // sticky window is cleared, so a later timeout can retrigger fronting.
+    assert_eq!(runtime.fronting_domain(), Some("sprinthost.ru"));
+}
+
+#[test]
+fn zero_cooldown_expires_immediately() {
+    let runtime = Runtime::new(OutboundConnector::direct())
+        .with_fronting(Some("sprinthost.ru".to_string()), Duration::from_secs(0));
+
+    runtime.activate_fronting();
+    // `Instant::now() + 0 <= Instant::now()` by the time we check, so the
+    // sticky window is effectively already expired.
+    std::thread::sleep(Duration::from_millis(1));
+    assert!(!runtime.fronting_active());
+}


### PR DESCRIPTION
## Summary

Ports the "domain fronting fallback" from upstream [Flowseal/tg-ws-proxy@c8f6f8c](https://github.com/Flowseal/tg-ws-proxy/commit/c8f6f8caf450b039f496388f7c849ff8f5db2f16), addressing #81. A commenter reported that commit fixed the same connectivity-degradation symptoms (stuck media, slow/stalled reconnects) that this repo's users are seeing, and the maintainer agreed to port it.

**What it does:** when direct WebSocket connects to a Telegram DC keep timing out (a sign of SNI-based DPI blocking), the proxy retries using an unrelated, presumably-unblocked domain as the **TLS SNI** while still connecting to Telegram's real DC IP and using the real DC domain as the **HTTP `Host`**. DPI that filters by SNI sees an allowed domain; the actual (TLS-encrypted) request still reaches Telegram normally.

- New flags: `--fronting-domain <DOMAIN>` (e.g. `sprinthost.ru`, disabled unless set) and `--fronting-cooldown <SECS>` (default 1800 = 30 min "sticky" window after a fronted connection succeeds, matching upstream).
- TLS certificate verification is **unconditionally skipped** on connections using this fallback — the real Telegram cert can never match a fronted SNI, so hostname verification would always fail. This is inherent to the technique (matches upstream's own behavior), not a regression, and only applies to this one fallback path.
- The sticky window also applies to background connection-pool refills, so a client doesn't get handed an un-fronted pooled connection while fronting is active.
- `tokio_tungstenite`'s TLS helper always derives SNI from the request's own host with no override hook, so the SNI-override path does the TLS handshake manually via `tokio_rustls` and then hands the established stream to `client_async_with_config` for the WS upgrade — same result type, no behavior change on the non-fronted path.

## Test plan
- [x] `cargo test` — all existing + new tests pass, including the pinned `tests/public_api.rs` signatures
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt --check`
- [x] New tests: `src/ws_client/tests.rs` proves the TLS SNI sent on the wire is the fronted domain while the WS `Host` stays real, and that certificate verification is skipped only on that path (a real handshake against a self-signed cert, using `tokio_rustls::LazyConfigAcceptor` to inspect the ClientHello's SNI server-side); `tests/runtime.rs` covers the sticky-window state machine; `tests/config.rs` covers the new flags (disabled by default)
- [x] Manual smoke test: ran the binary with `--fronting-domain sprinthost.ru`, confirmed the startup banner reports it enabled and the fallback chain logs as expected on WS failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)