### PR TITLE
fix: actively verify pooled WS connections before handing them to a client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ tg-ws-proxy [OPTIONS]
 | `--dc-ip <DC:IP>` | DC2 + DC4 | Target IP per DC (repeatable); omit when using `--cf-domain` to let CF proxy handle all DCs |
 | `--buf-kb <KB>` | `256` | Socket buffer size |
 | `--pool-size <N>` | `4` | Pre-warmed WS connections per DC |
+| `--pool-liveness-timeout <SECS>` | `1` | Bound on the active ping check before handing a pooled connection to a client — catches connections that silently died (e.g. a NAT mapping expiring during a long client idle period) instead of stalling on a TCP retransmission timeout |
 | `--cf-domain <DOMAIN>` | — | Cloudflare-proxied domain(s) for alternative WS routing, comma-separated (see [CF Proxy](#cloudflare-proxy)) |
 | `--cf-worker-domain <DOMAIN>` | — | Cloudflare Worker domain(s) for TCP-tunnel fallback, comma-separated/repeatable (see [Cloudflare Worker](#cloudflare-worker)) |
 | `--default-domains` | off | Fetch and use the built-in CF proxy domain list from GitHub (no Cloudflare setup needed, see [Default domains](#default-domains)) |
@@ -118,7 +119,7 @@ tg-ws-proxy [OPTIONS]
 | `--danger-accept-invalid-certs` | off | Skip TLS verification |
 
 Every flag has a matching environment variable (`TG_PORT`, `TG_HOST`,
-`TG_SECRET`, `TG_BUF_KB`, `TG_POOL_SIZE`, `TG_MAX_CONNECTIONS`, `TG_QUIET`,
+`TG_SECRET`, `TG_BUF_KB`, `TG_POOL_SIZE`, `TG_POOL_LIVENESS_TIMEOUT`, `TG_MAX_CONNECTIONS`, `TG_QUIET`,
 `TG_VERBOSE`, `TG_SKIP_TLS_VERIFY`, `TG_LINK_IP`, `TG_LISTEN_FAKETLS_DOMAIN`, `TG_MTPROTO_PROXY`,
 `TG_LOG_FILE`, `TG_CF_DOMAIN`, `TG_CF_WORKER_DOMAIN`, `TG_CF_PRIORITY`,
 `TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`, `TG_OUTBOUND_PROXY`, `TG_NO_OUTBOUND_PROXY`, `TG_NO_PROXY`,

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ tg-ws-proxy [OPTIONS]
 | `--dc-ip <DC:IP>` | DC2 + DC4 | Target IP per DC (repeatable); omit when using `--cf-domain` to let CF proxy handle all DCs |
 | `--buf-kb <KB>` | `256` | Socket buffer size |
 | `--pool-size <N>` | `4` | Pre-warmed WS connections per DC |
-| `--pool-liveness-timeout <SECS>` | `1` | Bound on the active ping check before handing a pooled connection to a client — catches connections that silently died (e.g. a NAT mapping expiring during a long client idle period) instead of stalling on a TCP retransmission timeout |
+| `--pool-liveness-timeout <SECS>` | `1` | Bound on the active ping check before handing a pooled connection to a client — catches connections that silently died (e.g. a NAT mapping expiring during a long client idle period) instead of stalling on a TCP retransmission timeout. `0` disables the active probe (old passive-only check) |
 | `--cf-domain <DOMAIN>` | — | Cloudflare-proxied domain(s) for alternative WS routing, comma-separated (see [CF Proxy](#cloudflare-proxy)) |
 | `--cf-worker-domain <DOMAIN>` | — | Cloudflare Worker domain(s) for TCP-tunnel fallback, comma-separated/repeatable (see [Cloudflare Worker](#cloudflare-worker)) |
 | `--default-domains` | off | Fetch and use the built-in CF proxy domain list from GitHub (no Cloudflare setup needed, see [Default domains](#default-domains)) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -368,6 +368,12 @@ pub struct Config {
     /// (commonly 15-30s). This bounds that to a short, predictable wait
     /// instead. Raise it if you see spurious pool discards on a
     /// high-latency path to your configured DC IPs.
+    ///
+    /// Set to `0` to disable the active probe and fall back to the old
+    /// passive check, which only catches a connection that already sent a
+    /// close/error frame (i.e. the silent-death case above goes undetected
+    /// again). Useful if the extra per-hit round trip is undesirable and you
+    /// don't hit the failure mode this exists for.
     #[arg(
         long = "pool-liveness-timeout",
         default_value = "1",

--- a/src/config.rs
+++ b/src/config.rs
@@ -358,6 +358,23 @@ pub struct Config {
     #[arg(long = "pool-max-age", default_value = "55", env = "TG_POOL_MAX_AGE")]
     pub pool_max_age: u64,
 
+    /// Timeout in seconds for the active liveness probe (a WebSocket ping)
+    /// performed on a pooled connection before it is handed to a client.
+    ///
+    /// A pooled connection can go silently dead (e.g. a NAT/firewall mapping
+    /// expiring while the client machine was asleep) without either side
+    /// seeing a close — handing it out as-is would only surface the failure
+    /// once real traffic hits an OS-level TCP retransmission timeout
+    /// (commonly 15-30s). This bounds that to a short, predictable wait
+    /// instead. Raise it if you see spurious pool discards on a
+    /// high-latency path to your configured DC IPs.
+    #[arg(
+        long = "pool-liveness-timeout",
+        default_value = "1",
+        env = "TG_POOL_LIVENESS_TIMEOUT"
+    )]
+    pub pool_liveness_timeout: u64,
+
     /// Test configured Cloudflare proxy domains and upstream MTProto proxies
     /// for suitability, then exit.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,9 +295,10 @@ async fn main() {
     info!("{}", "=".repeat(60));
 
     // ── Connection pool warm-up ───────────────────────────────────────────
-    let pool = Arc::new(WsPool::with_runtime(
+    let pool = Arc::new(WsPool::with_liveness_timeout(
         config.pool_size,
         Duration::from_secs(config.pool_max_age),
+        Duration::from_secs(config.pool_liveness_timeout),
         Arc::clone(&runtime),
     ));
     {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -28,7 +28,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{FutureExt, SinkExt, StreamExt};
 use tungstenite::Message;
 
 use crate::config::Config;
@@ -178,6 +178,15 @@ impl WsPool {
     /// to a client, bounding the wait instead of trusting a passive check.
     /// See the module-level docs for why this matters.
     async fn is_alive(ws: &mut TgWsStream, timeout: Duration) -> bool {
+        if timeout.is_zero() {
+            // `--pool-liveness-timeout 0` opts out of the active probe for
+            // callers who'd rather not pay even a small per-hit RTT cost.
+            // Fall back to the pre-existing passive check: it only catches a
+            // connection that already sent a close/error frame, not a
+            // silently dead one — see the module docs.
+            return ws.next().now_or_never().is_none();
+        }
+
         if ws.send(Message::Ping(Vec::new())).await.is_err() {
             return false;
         }
@@ -420,6 +429,34 @@ mod tests {
         assert!(
             result.is_some(),
             "a connection that answers the ping should still be handed out"
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn zero_liveness_timeout_skips_the_active_probe() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Server never sends anything — with the active probe this would be
+        // discarded, but a liveness_timeout of 0 opts back into the old
+        // passive-only check, which has nothing to detect here (no
+        // close/error frame was ever sent), so the entry is handed out as-is.
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let _ws = tokio_tungstenite::accept_async(tcp).await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let pool = make_pool(Duration::ZERO);
+        seed_entry(&pool, 2, false, connect_plain_ws(addr).await).await;
+
+        let result = pool.get(2, false, "203.0.113.10".to_string(), false).await;
+
+        assert!(
+            result.is_some(),
+            "pool-liveness-timeout=0 should skip the active probe entirely"
         );
 
         server.abort();

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -6,6 +6,19 @@
 //!
 //! The pool is keyed by `(dc_id, is_media)`.  Background refill tasks run
 //! after each pool hit to keep the bucket at `pool_size` connections.
+//!
+//! ## Active liveness check
+//!
+//! A pooled connection can go silently dead without either side ever seeing a
+//! FIN/RST — e.g. a NAT/firewall mapping between us and Telegram expiring
+//! while the *client* machine was asleep for a long stretch has nothing to do
+//! with our end of the socket, so it looks perfectly fine to a passive check.
+//! If such a connection were handed to a client, the first real write (the
+//! relay-init packet) would sit in the OS send buffer until a TCP
+//! retransmission timeout gives up — commonly 15-30s — before the caller
+//! finds out. `get()` instead sends a WS ping and bounds the wait for any
+//! response to `pool_liveness_timeout`, so a dead entry is caught and
+//! discarded quickly instead of stalling the client's request.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -15,12 +28,17 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
-use futures_util::{FutureExt, StreamExt};
+use futures_util::{SinkExt, StreamExt};
+use tungstenite::Message;
 
 use crate::config::Config;
 use crate::outbound::OutboundConnector;
 use crate::runtime::Runtime;
 use crate::ws_client::{TgWsStream, connect_ws_for_dc_with_outbound};
+
+/// Default bound on the active liveness probe when a pool is built via
+/// [`WsPool::new`] without an explicit timeout (see `with_runtime`).
+const DEFAULT_LIVENESS_TIMEOUT: Duration = Duration::from_secs(1);
 
 struct PoolEntry {
     ws: TgWsStream,
@@ -35,6 +53,9 @@ pub struct WsPool {
     /// Maximum age for a pooled connection.  Connections older than this are
     /// discarded on next use rather than handed to a client.
     max_age: Duration,
+    /// Bound on the active liveness probe performed in `get()` before a
+    /// pooled connection is handed to a client. See the module docs.
+    liveness_timeout: Duration,
     runtime: Arc<Runtime>,
     idle: Mutex<PoolMap>,
     /// Tracks which (dc, is_media) buckets currently have a refill in flight.
@@ -71,19 +92,29 @@ impl WsPool {
     }
 
     pub fn with_runtime(pool_size: usize, max_age: Duration, runtime: Arc<Runtime>) -> Self {
+        Self::with_liveness_timeout(pool_size, max_age, DEFAULT_LIVENESS_TIMEOUT, runtime)
+    }
+
+    pub fn with_liveness_timeout(
+        pool_size: usize,
+        max_age: Duration,
+        liveness_timeout: Duration,
+        runtime: Arc<Runtime>,
+    ) -> Self {
         Self {
             pool_size,
             max_age,
+            liveness_timeout,
             runtime,
             idle: Mutex::new(HashMap::new()),
             refilling: StdMutex::new(HashSet::new()),
         }
     }
 
-    /// Take a pre-warmed connection from the pool, if available and fresh.
+    /// Take a pre-warmed connection from the pool, if available and live.
     ///
     /// Returns `Some(ws)` on a pool hit, `None` if the bucket is empty or
-    /// all entries were stale.  Schedules a background refill either way.
+    /// every entry was stale/dead.  Schedules a background refill either way.
     pub async fn get(
         self: &Arc<Self>,
         dc: u32,
@@ -92,39 +123,38 @@ impl WsPool {
         skip_tls_verify: bool,
     ) -> Option<TgWsStream> {
         let now = Instant::now();
-        let mut lock = self.idle.lock().await;
-        let bucket = lock.entry((dc, is_media)).or_default();
 
-        // Drain from the back (LIFO) so the freshest connections are used first.
-        while let Some(mut entry) = bucket.pop() {
+        loop {
+            // Pop one candidate at a time and release the lock before the
+            // (potentially slow) liveness check below, so a dead entry on one
+            // bucket doesn't stall `get()` calls for every other DC/media
+            // bucket, which all share this single mutex.
+            let mut entry = {
+                let mut lock = self.idle.lock().await;
+                match lock.entry((dc, is_media)).or_default().pop() {
+                    Some(entry) => entry,
+                    None => break,
+                }
+            };
+
             if now.saturating_duration_since(entry.created) > self.max_age {
                 // Entry is stale; drop it (close happens on drop via tungstenite).
                 continue;
             }
 
-            // Non-blocking liveness check: if the server has already closed the
-            // WebSocket (TCP FIN received), `next()` resolves immediately with
-            // `None` or an error.  Any message arriving on an idle pre-warmed
-            // connection (close, error, or unexpected data) is treated as a sign
-            // that the connection is in an invalid state and should be discarded.
-            if entry.ws.next().now_or_never().is_some() {
+            if !Self::is_alive(&mut entry.ws, self.liveness_timeout).await {
+                // Covers both an already-closed connection (the check returns
+                // near-instantly) and a silently dead one that never answers
+                // within `liveness_timeout` — see the module docs.
                 debug!(
-                    "pool: discarding stale DC{}{} connection",
+                    "pool: discarding dead DC{}{} connection",
                     dc,
                     if is_media { "m" } else { "" }
                 );
                 continue;
             }
 
-            let remaining = bucket.len();
-            drop(lock);
-
-            debug!(
-                "pool hit DC{}{} ({} left)",
-                dc,
-                if is_media { "m" } else { "" },
-                remaining
-            );
+            debug!("pool hit DC{}{}", dc, if is_media { "m" } else { "" });
 
             // Schedule a background task to refill the bucket.
             let pool = Arc::clone(self);
@@ -135,15 +165,30 @@ impl WsPool {
             return Some(entry.ws);
         }
 
-        // Bucket is empty (or fully stale).
-        drop(lock);
-
+        // Bucket is empty (or every entry was stale/dead).
         let pool = Arc::clone(self);
         tokio::spawn(async move {
             pool.refill(dc, is_media, target_ip, skip_tls_verify).await;
         });
 
         None
+    }
+
+    /// Actively verify a pooled connection is still usable before handing it
+    /// to a client, bounding the wait instead of trusting a passive check.
+    /// See the module-level docs for why this matters.
+    async fn is_alive(ws: &mut TgWsStream, timeout: Duration) -> bool {
+        if ws.send(Message::Ping(Vec::new())).await.is_err() {
+            return false;
+        }
+
+        // Any successfully received frame (a Pong, or anything else) proves
+        // the round trip to Telegram still works.  Timing out, an error, or
+        // a graceful close all mean the entry cannot be trusted.
+        matches!(
+            tokio::time::timeout(timeout, ws.next()).await,
+            Ok(Some(Ok(_)))
+        )
     }
 
     /// Warm up the pool for all configured DCs on startup.
@@ -275,5 +320,108 @@ impl WsPool {
             }
         }
         results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::MaybeTlsStream;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    /// Connect a plain (non-TLS) `TgWsStream` to a local WS server, wrapped
+    /// in `MaybeTlsStream::Plain` so the type matches production pooled
+    /// entries without needing a real TLS handshake in tests.
+    async fn connect_plain_ws(addr: std::net::SocketAddr) -> TgWsStream {
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let request = format!("ws://{addr}/apiws").into_client_request().unwrap();
+        let (ws, _response) = tokio_tungstenite::client_async(request, MaybeTlsStream::Plain(tcp))
+            .await
+            .unwrap();
+        ws
+    }
+
+    fn make_pool(liveness_timeout: Duration) -> Arc<WsPool> {
+        Arc::new(WsPool::with_liveness_timeout(
+            1,
+            Duration::from_secs(60),
+            liveness_timeout,
+            Arc::new(Runtime::new(OutboundConnector::direct())),
+        ))
+    }
+
+    async fn seed_entry(pool: &Arc<WsPool>, dc: u32, is_media: bool, ws: TgWsStream) {
+        pool.idle
+            .lock()
+            .await
+            .entry((dc, is_media))
+            .or_default()
+            .push(PoolEntry {
+                ws,
+                created: Instant::now(),
+            });
+    }
+
+    #[tokio::test]
+    async fn get_discards_a_silently_dead_connection_within_the_liveness_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Server accepts the WS upgrade, then goes silent — never reads or
+        // writes again, simulating a connection that's dead from Telegram's
+        // side without ever sending a close frame.
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let _ws = tokio_tungstenite::accept_async(tcp).await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let pool = make_pool(Duration::from_millis(150));
+        seed_entry(&pool, 2, false, connect_plain_ws(addr).await).await;
+
+        let start = Instant::now();
+        let result = pool.get(2, false, "203.0.113.10".to_string(), false).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_none(), "dead connection should be discarded");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "get() took {elapsed:?}, should bail out within the liveness timeout"
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn get_returns_a_connection_that_answers_the_liveness_ping() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Server accepts the WS upgrade, reads the incoming ping, and
+        // explicitly replies with a Pong so the client-side liveness check
+        // sees a real flushed response rather than relying on tungstenite's
+        // internal auto-queued reply (which isn't flushed until the next
+        // write anyway).
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(tcp).await.unwrap();
+            if let Some(Ok(Message::Ping(payload))) = ws.next().await {
+                let _ = ws.send(Message::Pong(payload)).await;
+            }
+            std::future::pending::<()>().await;
+        });
+
+        let pool = make_pool(Duration::from_millis(500));
+        seed_entry(&pool, 2, false, connect_plain_ws(addr).await).await;
+
+        let result = pool.get(2, false, "203.0.113.10".to_string(), false).await;
+
+        assert!(
+            result.is_some(),
+            "a connection that answers the ping should still be handed out"
+        );
+
+        server.abort();
     }
 }


### PR DESCRIPTION
## Summary

Reopens the investigation on #81. The fronting-fallback PR (#87) doesn't touch pool hits at all, so it couldn't have addressed the "media takes ~20s to start loading after the client machine wakes from sleep" symptom reported there — this is a separate, pre-existing bug in the connection pool.

**Root cause:** `WsPool::get()`'s liveness check (`entry.ws.next().now_or_never()`) is passive — it only catches a connection that has *already* sent a close/error frame. A connection that goes silently dead (e.g. a NAT/firewall mapping between the proxy and Telegram expiring while the client machine was asleep for a long stretch) passes this check just fine, since neither side ever sent a FIN/RST. When such a connection was handed to a client, the first real write (the relay-init packet in `bridge_ws`) would silently sit in the OS send buffer until a TCP retransmission timeout gave up — commonly 15-30s on Linux, which lines up closely with the "~20 seconds" delay reported by Dum4G.

**Fix:** `WsPool::get()` now performs an active liveness probe — sends a WS ping and bounds the wait for any response to a new `--pool-liveness-timeout` (default 1s) — before handing a pooled connection out. Entries that don't answer in time are discarded and the caller falls through to the normal fresh-connect path, same as a pool miss. The pool-map lock is only held for the pop, not across the (potentially slow) check, so one dead entry doesn't stall `get()` calls for other DC/media buckets.

## Test plan
- [x] `cargo test` — all existing tests pass, plus 2 new unit tests in `src/pool.rs`:
  - a pooled connection that never answers the ping is discarded within the timeout (not the ~20-30s OS timeout)
  - a pooled connection that does answer is still handed out normally
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt`
- [x] Manually ran the proxy against a real Telegram Desktop client (CF proxy path) before and after the change — connects and bridges data with no errors in either run

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)