### PR TITLE
feat: make domain fronting reachable when --dc-ip is unconfigured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -451,12 +451,20 @@ refills) for `--fronting-cooldown` seconds (default 1800 = 30 min), so the
 proxy doesn't keep re-probing the likely-still-blocked direct path on every
 new connection.
 
+Fronting is tried in two places: right after a direct WebSocket attempt times
+out (when `--dc-ip` is configured for that DC), and — since most setups rely
+on `--cf-domain`/`--default-domains` instead of `--dc-ip` — as a last resort
+after CF Worker/CF proxy/upstream proxy fallbacks are exhausted, before the
+proxy would otherwise fall through to a plain direct TCP connection (which is
+normally dead weight for anyone who needed a CF fallback in the first place,
+since direct Telegram connectivity is usually what's blocked for them).
+
 > **Note:** TLS certificate verification is unconditionally skipped on
 > connections using this fallback, regardless of
 > `--danger-accept-invalid-certs` — the real Telegram certificate can never
 > match a fronted SNI, so hostname verification would always fail. This is
-> inherent to the technique, not a bug, and only applies to the direct-WS
-> fallback path (not CF proxy/Worker connections).
+> inherent to the technique, not a bug, and only applies to fronted
+> connections (not CF proxy/Worker connections).
 
 ### Default domains
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ tg-ws-proxy [OPTIONS]
 | `--cf-balance` | off | Round-robin load balance across multiple `--cf-domain` and `--cf-worker-domain` values (see [CF Proxy](#cloudflare-proxy)) |
 | `--fronting-domain <DOMAIN>` | off | Domain-fronting fallback SNI, e.g. `sprinthost.ru` (see [Domain fronting](#domain-fronting)) |
 | `--fronting-cooldown <SECS>` | `1800` | How long the fronting fallback stays active after it last succeeded |
+| `--fronting-fail-cooldown <SECS>` | `60` | How long to stop retrying fronting after it fails (protects against networks that block Telegram's DC IPs outright, where fronting can never succeed) |
 | `--max-connections <N>` | auto | Max concurrent client connections (auto-computed from `ulimit -n`) |
 | `--mtproto-proxy <HOST:PORT:SECRET>` | — | Upstream MTProto proxy fallback (repeatable) |
 | `--outbound-proxy <URL>` | — | Proxy for all outgoing connections: `http://`, `socks5://`, or `socks5h://`; `https://` proxy URLs are not supported |
@@ -122,7 +123,7 @@ Every flag has a matching environment variable (`TG_PORT`, `TG_HOST`,
 `TG_VERBOSE`, `TG_SKIP_TLS_VERIFY`, `TG_LINK_IP`, `TG_LISTEN_FAKETLS_DOMAIN`, `TG_MTPROTO_PROXY`,
 `TG_LOG_FILE`, `TG_CF_DOMAIN`, `TG_CF_WORKER_DOMAIN`, `TG_CF_PRIORITY`,
 `TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`, `TG_OUTBOUND_PROXY`, `TG_NO_OUTBOUND_PROXY`, `TG_NO_PROXY`,
-`TG_FRONTING_DOMAIN`, `TG_FRONTING_COOLDOWN`).
+`TG_FRONTING_DOMAIN`, `TG_FRONTING_COOLDOWN`, `TG_FRONTING_FAIL_COOLDOWN`).
 When `TG_OUTBOUND_PROXY` is not set, standard `HTTPS_PROXY`, `ALL_PROXY`,
 `HTTP_PROXY` and `NO_PROXY` environment variables are also honored. `https://`
 proxy URLs are skipped when discovered from the standard environment if a later
@@ -458,6 +459,13 @@ after CF Worker/CF proxy/upstream proxy fallbacks are exhausted, before the
 proxy would otherwise fall through to a plain direct TCP connection (which is
 normally dead weight for anyone who needed a CF fallback in the first place,
 since direct Telegram connectivity is usually what's blocked for them).
+
+Fronting only helps against SNI-based DPI — it does nothing on a network
+that blocks Telegram's DC IPs outright, since the fronted attempt still has
+to open a real TCP connection to that IP. If a fronting attempt fails,
+`--fronting-fail-cooldown` seconds (default 60) pass before it's retried for
+that DC, so a network where fronting can never succeed doesn't pay for a
+doomed attempt on every single connection.
 
 > **Note:** TLS certificate verification is unconditionally skipped on
 > connections using this fallback, regardless of

--- a/src/config.rs
+++ b/src/config.rs
@@ -353,6 +353,22 @@ pub struct Config {
     )]
     pub fronting_cooldown: u64,
 
+    /// Seconds to stop retrying the domain-fronting fallback after it fails.
+    ///
+    /// Fronting only helps against SNI-based DPI blocking — it does nothing
+    /// for a network that blocks Telegram's DC IPs outright (the fronted
+    /// attempt still has to open a real TCP connection to that IP, just with
+    /// a different SNI). Without this cooldown, every single connection on
+    /// such a network would retry fronting from scratch and pay a full
+    /// `--ws-connect-timeout` for a doomed attempt on top of the already
+    /// doomed direct/CF/TCP attempts, compounding delays instead of helping.
+    #[arg(
+        long = "fronting-fail-cooldown",
+        default_value = "60",
+        env = "TG_FRONTING_FAIL_COOLDOWN"
+    )]
+    pub fronting_fail_cooldown: u64,
+
     /// Maximum age of a pooled WebSocket connection in seconds.
     /// Connections older than this are discarded and re-established.
     #[arg(long = "pool-max-age", default_value = "55", env = "TG_POOL_MAX_AGE")]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -723,6 +723,59 @@ pub async fn handle_client_with_runtime(
             }
         }
 
+        // ── Try domain fronting (SNI spoofing) as a last resort before the
+        // TCP fallback below. Direct TCP to Telegram's real IP is dead
+        // weight for anyone relying on CF/worker/upstream in the first
+        // place — they're almost certainly here because direct Telegram is
+        // blocked outright — whereas fronting has an actual chance of
+        // getting through SNI-based DPI, using the same fallback IP the TCP
+        // attempt below would otherwise use.
+        if let Some(domain) = runtime.fronting_domain() {
+            info!(
+                "[{}] DC{}{} {} → trying fronting (SNI {})",
+                label, dc_id, media_tag, reason, domain
+            );
+
+            let (front_opt, _all_redirects, _timed_out) = connect_ws_for_dc_with_outbound(
+                &fallback,
+                ws_dc,
+                is_media,
+                skip_tls,
+                ws_connect_timeout,
+                runtime.outbound(),
+                Some(domain),
+            )
+            .await;
+
+            if let Some(ws) = front_opt {
+                runtime.activate_fronting();
+                info!(
+                    "[{}] DC{}{} {} → fronting connected (SNI {})",
+                    label, dc_id, media_tag, reason, domain
+                );
+                bridge_ws(
+                    reader,
+                    writer,
+                    WsBridgeParams {
+                        label: &label,
+                        ws,
+                        relay_init,
+                        ciphers,
+                        proto,
+                        dc: dc_id,
+                        is_media,
+                    },
+                )
+                .await;
+                return;
+            } else {
+                warn!(
+                    "[{}] DC{}{} fronting fallback failed",
+                    label, dc_id, media_tag
+                );
+            }
+        }
+
         info!("[{}] {} → TCP fallback {}:443", label, reason, fallback);
 
         bridge_tcp(

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -197,6 +197,38 @@ fn cf_worker_in_cooldown(worker_domain: &str) -> bool {
     false
 }
 
+// ─── Domain-fronting failure tracking ────────────────────────────────────────
+
+/// Per-DC cooldown for a *failed* fronting attempt — distinct from
+/// `Runtime`'s sticky "fronting is currently working" state. Without this,
+/// a network that blocks Telegram's DC IPs outright (not just by SNI) would
+/// retry a doomed fronting attempt on every single connection; see
+/// `Config::fronting_fail_cooldown`.
+static FRONTING_FAIL_UNTIL: StdMutex<Option<HashMap<(u32, bool), Instant>>> = StdMutex::new(None);
+
+fn set_fronting_fail_cooldown(dc: u32, is_media: bool, cooldown: Duration) {
+    let mut lock = FRONTING_FAIL_UNTIL.lock().unwrap();
+    lock.get_or_insert_with(HashMap::new)
+        .insert((dc, is_media), Instant::now() + cooldown);
+}
+
+fn clear_fronting_fail_cooldown(dc: u32, is_media: bool) {
+    let mut lock = FRONTING_FAIL_UNTIL.lock().unwrap();
+    if let Some(map) = lock.as_mut() {
+        map.remove(&(dc, is_media));
+    }
+}
+
+fn fronting_in_fail_cooldown(dc: u32, is_media: bool) -> bool {
+    let lock = FRONTING_FAIL_UNTIL.lock().unwrap();
+    if let Some(map) = lock.as_ref()
+        && let Some(&until) = map.get(&(dc, is_media))
+    {
+        return Instant::now() < until;
+    }
+    false
+}
+
 fn blacklist_ws(dc: u32, is_media: bool, cooldown: Duration) {
     // Instead of a permanent blacklist, apply a long cooldown so the proxy
     // can recover automatically if WS becomes available again (e.g. after a
@@ -396,6 +428,7 @@ pub async fn handle_client_with_runtime(
     let upstream_fail_cooldown = Duration::from_secs(config.upstream_fail_cooldown);
     let cf_connect_timeout = Duration::from_secs(config.cf_connect_timeout);
     let cf_fail_cooldown = Duration::from_secs(config.cf_fail_cooldown);
+    let fronting_fail_cooldown = Duration::from_secs(config.fronting_fail_cooldown);
 
     // Split into independent read / write halves.
     let (mut reader, mut writer) = tokio::io::split(stream);
@@ -731,48 +764,60 @@ pub async fn handle_client_with_runtime(
         // getting through SNI-based DPI, using the same fallback IP the TCP
         // attempt below would otherwise use.
         if let Some(domain) = runtime.fronting_domain() {
-            info!(
-                "[{}] DC{}{} {} → trying fronting (SNI {})",
-                label, dc_id, media_tag, reason, domain
-            );
-
-            let (front_opt, _all_redirects, _timed_out) = connect_ws_for_dc_with_outbound(
-                &fallback,
-                ws_dc,
-                is_media,
-                skip_tls,
-                ws_connect_timeout,
-                runtime.outbound(),
-                Some(domain),
-            )
-            .await;
-
-            if let Some(ws) = front_opt {
-                runtime.activate_fronting();
-                info!(
-                    "[{}] DC{}{} {} → fronting connected (SNI {})",
-                    label, dc_id, media_tag, reason, domain
-                );
-                bridge_ws(
-                    reader,
-                    writer,
-                    WsBridgeParams {
-                        label: &label,
-                        ws,
-                        relay_init,
-                        ciphers,
-                        proto,
-                        dc: dc_id,
-                        is_media,
-                    },
-                )
-                .await;
-                return;
-            } else {
-                warn!(
-                    "[{}] DC{}{} fronting fallback failed",
+            if fronting_in_fail_cooldown(dc_id, is_media) {
+                debug!(
+                    "[{}] DC{}{} fronting in cooldown, skipping straight to TCP fallback",
                     label, dc_id, media_tag
                 );
+            } else {
+                info!(
+                    "[{}] DC{}{} {} → trying fronting (SNI {})",
+                    label, dc_id, media_tag, reason, domain
+                );
+
+                let (front_opt, _all_redirects, _timed_out) = connect_ws_for_dc_with_outbound(
+                    &fallback,
+                    ws_dc,
+                    is_media,
+                    skip_tls,
+                    ws_connect_timeout,
+                    runtime.outbound(),
+                    Some(domain),
+                )
+                .await;
+
+                if let Some(ws) = front_opt {
+                    clear_fronting_fail_cooldown(dc_id, is_media);
+                    runtime.activate_fronting();
+                    info!(
+                        "[{}] DC{}{} {} → fronting connected (SNI {})",
+                        label, dc_id, media_tag, reason, domain
+                    );
+                    bridge_ws(
+                        reader,
+                        writer,
+                        WsBridgeParams {
+                            label: &label,
+                            ws,
+                            relay_init,
+                            ciphers,
+                            proto,
+                            dc: dc_id,
+                            is_media,
+                        },
+                    )
+                    .await;
+                    return;
+                } else {
+                    set_fronting_fail_cooldown(dc_id, is_media, fronting_fail_cooldown);
+                    warn!(
+                        "[{}] DC{}{} fronting fallback failed, cooldown {}s",
+                        label,
+                        dc_id,
+                        media_tag,
+                        fronting_fail_cooldown.as_secs()
+                    );
+                }
             }
         }
 
@@ -904,9 +949,13 @@ pub async fn handle_client_with_runtime(
                 );
             } else {
                 runtime.deactivate_fronting();
+                set_fronting_fail_cooldown(dc_id, is_media, fronting_fail_cooldown);
                 warn!(
-                    "[{}] DC{}{} fronting (sticky) failed, falling back",
-                    label, dc_id, media_tag
+                    "[{}] DC{}{} fronting (sticky) failed, falling back, cooldown {}s",
+                    label,
+                    dc_id,
+                    media_tag,
+                    fronting_fail_cooldown.as_secs()
                 );
             }
         } else if ws_opt.is_some() {
@@ -916,11 +965,17 @@ pub async fn handle_client_with_runtime(
                 "[{}] DC{}{} → WS connected via {}",
                 label, dc_id, media_tag, target_ip
             );
-        } else if timed_out && let Some(domain) = runtime.fronting_domain() {
+        } else if timed_out
+            && !fronting_in_fail_cooldown(dc_id, is_media)
+            && let Some(domain) = runtime.fronting_domain()
+        {
             // Reactive fronting: the normal (non-fronted) attempt above
             // timed out — a sign of SNI-based DPI blocking — so try once
             // more with the fronted SNI before falling back to cooldown +
-            // CF/upstream/TCP.
+            // CF/upstream/TCP. Skipped while a previous fronting attempt is
+            // in its own fail-cooldown (see `fronting_fail_cooldown` docs) —
+            // a network that blocks the DC IP outright would otherwise pay
+            // for this doomed attempt on every single connection.
             info!(
                 "[{}] DC{}{} WS timed out → trying fronting (SNI {})",
                 label, dc_id, media_tag, domain
@@ -938,15 +993,20 @@ pub async fn handle_client_with_runtime(
             .await;
 
             if front_opt.is_some() {
+                clear_fronting_fail_cooldown(dc_id, is_media);
                 runtime.activate_fronting();
                 info!(
                     "[{}] DC{}{} → fronting connected (SNI {})",
                     label, dc_id, media_tag, domain
                 );
             } else {
+                set_fronting_fail_cooldown(dc_id, is_media, fronting_fail_cooldown);
                 warn!(
-                    "[{}] DC{}{} fronting fallback failed",
-                    label, dc_id, media_tag
+                    "[{}] DC{}{} fronting fallback failed, cooldown {}s",
+                    label,
+                    dc_id,
+                    media_tag,
+                    fronting_fail_cooldown.as_secs()
                 );
             }
             ws_opt = front_opt;

--- a/tests/outbound_call_sites.rs
+++ b/tests/outbound_call_sites.rs
@@ -259,6 +259,55 @@ async fn proxy_tcp_fallback_uses_outbound_proxy() {
     assert!(request.starts_with("CONNECT 149.154.167.51:443 HTTP/1.1"));
 }
 
+#[tokio::test]
+async fn proxy_tries_fronting_before_tcp_fallback_when_dc_ip_is_unconfigured() {
+    // Regression test for issue #81: fronting was only wired into the
+    // `--dc-ip`-configured branch, making it unreachable for the far more
+    // common case of relying solely on --cf-domain/--default-domains (which
+    // suppresses the built-in --dc-ip defaults, see Config::from_args).
+    // With no CF domain/worker/upstream proxy configured, WS trying to reach
+    // Telegram directly is expected to fail (no real DC connectivity in this
+    // test), so the flow should now attempt a fronted WS connect (SNI
+    // override) before falling through to the plain TCP fallback below it —
+    // both attempts open a fresh outbound TCP connection, so the rejecting
+    // proxy should see exactly 2 CONNECT requests instead of 1.
+    let (proxy_addr, proxy_task) = rejecting_http_proxy_requests(2).await;
+    let config = Config::try_parse_from([
+        "tg-ws-proxy",
+        "--secret",
+        "00112233445566778899aabbccddeeff",
+        "--fronting-domain",
+        "sprinthost.ru",
+        "--outbound-proxy",
+        &format!("http://{proxy_addr}"),
+        "--no-outbound-proxy",
+        "--no-proxy",
+        "",
+        "--handshake-timeout",
+        "2",
+        "--ws-connect-timeout",
+        "2",
+        "--tcp-fallback-timeout",
+        "2",
+    ])
+    .unwrap();
+
+    run_proxy_once(config).await;
+
+    let requests = await_proxy_requests(proxy_task).await;
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected a fronting attempt followed by the TCP fallback, got {requests:?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|r| r.starts_with("CONNECT 149.154.167.51:443 HTTP/1.1")),
+        "both attempts should target the same fallback DC IP, got {requests:?}"
+    );
+}
+
 async fn rejecting_http_proxy() -> (std::net::SocketAddr, tokio::task::JoinHandle<String>) {
     let (addr, task) = rejecting_http_proxy_requests(1).await;
     let task = tokio::spawn(async move { await_proxy_requests(task).await.remove(0) });
@@ -352,7 +401,10 @@ async fn read_http_connect_request(stream: &mut TcpStream) -> String {
 async fn run_proxy_once(config: Config) {
     let secret = config.secret_bytes();
     let outbound = config.outbound_connector().unwrap();
-    let runtime = Arc::new(Runtime::new(outbound));
+    let runtime = Arc::new(Runtime::new(outbound).with_fronting(
+        config.fronting_domain.clone(),
+        Duration::from_secs(config.fronting_cooldown),
+    ));
     let pool = Arc::new(WsPool::with_runtime(
         0,
         Duration::from_secs(config.pool_max_age),

--- a/tests/outbound_call_sites.rs
+++ b/tests/outbound_call_sites.rs
@@ -289,6 +289,10 @@ async fn proxy_tries_fronting_before_tcp_fallback_when_dc_ip_is_unconfigured() {
         "2",
         "--tcp-fallback-timeout",
         "2",
+        // Avoid leaking a fronting fail-cooldown into other tests sharing
+        // this binary's global cooldown state (see `run_proxy_once_for_dc`).
+        "--fronting-fail-cooldown",
+        "0",
     ])
     .unwrap();
 
@@ -305,6 +309,64 @@ async fn proxy_tries_fronting_before_tcp_fallback_when_dc_ip_is_unconfigured() {
             .iter()
             .all(|r| r.starts_with("CONNECT 149.154.167.51:443 HTTP/1.1")),
         "both attempts should target the same fallback DC IP, got {requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn fronting_failure_is_not_retried_within_the_fail_cooldown() {
+    // Regression test: a network that blocks Telegram's DC IPs outright (not
+    // just by SNI) makes every fronting attempt fail the same way direct/CF
+    // do. Without a fail-cooldown, each new connection would retry fronting
+    // from scratch and pay a full --ws-connect-timeout for a doomed attempt
+    // on top of the already-doomed CF/TCP attempts — this is what happened
+    // in issue #81 after the fronting-in-CF-fallback change (#89) shipped
+    // without one. Uses DC 5 (unused by other tests in this file) since the
+    // fail-cooldown is tracked in a static shared across the whole test
+    // binary process.
+    let (proxy_addr, proxy_task) = rejecting_http_proxy_requests(3).await;
+    let make_config = || {
+        Config::try_parse_from([
+            "tg-ws-proxy",
+            "--secret",
+            "00112233445566778899aabbccddeeff",
+            "--fronting-domain",
+            "sprinthost.ru",
+            "--fronting-fail-cooldown",
+            "120",
+            "--outbound-proxy",
+            &format!("http://{proxy_addr}"),
+            "--no-outbound-proxy",
+            "--no-proxy",
+            "",
+            "--handshake-timeout",
+            "2",
+            "--ws-connect-timeout",
+            "2",
+            "--tcp-fallback-timeout",
+            "2",
+        ])
+        .unwrap()
+    };
+
+    // First connection: fronting is attempted (and fails), setting the
+    // cooldown, then falls through to the TCP fallback — 2 CONNECTs.
+    run_proxy_once_for_dc(make_config(), 5).await;
+    // Second connection, moments later: fronting should be skipped because
+    // it's still in its fail-cooldown, going straight to TCP — 1 CONNECT.
+    run_proxy_once_for_dc(make_config(), 5).await;
+
+    let requests = await_proxy_requests(proxy_task).await;
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected fronting+TCP on the first connection but only TCP on the \
+         second (cooldown active), got {requests:?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|r| r.starts_with("CONNECT 149.154.171.5:443 HTTP/1.1")),
+        "all attempts should target DC5's fallback IP, got {requests:?}"
     );
 }
 
@@ -399,6 +461,13 @@ async fn read_http_connect_request(stream: &mut TcpStream) -> String {
 }
 
 async fn run_proxy_once(config: Config) {
+    run_proxy_once_for_dc(config, 2).await;
+}
+
+/// Same as [`run_proxy_once`], but lets the caller pick the DC so tests that
+/// touch DC-keyed global cooldown state (e.g. the fronting fail-cooldown)
+/// don't collide with other tests sharing the same test binary process.
+async fn run_proxy_once_for_dc(config: Config, dc: i16) {
     let secret = config.secret_bytes();
     let outbound = config.outbound_connector().unwrap();
     let runtime = Arc::new(Runtime::new(outbound).with_fronting(
@@ -422,7 +491,7 @@ async fn run_proxy_once(config: Config) {
     let proxy_task = tokio::spawn(handle_client_with_runtime(
         server, peer, config, pool, runtime,
     ));
-    let (handshake, _, _) = generate_client_handshake(&secret, 2, ProtoTag::PaddedIntermediate);
+    let (handshake, _, _) = generate_client_handshake(&secret, dc, ProtoTag::PaddedIntermediate);
     client.write_all(&handshake).await.unwrap();
     drop(client);
 


### PR DESCRIPTION
## Summary

Follow-up on #81. Fronting (#87) was only wired into the `--dc-ip`-configured branch of the fallback chain. But `Config::from_args()` suppresses the built-in `--dc-ip` defaults whenever `--cf-domain` or `--default-domains` is set (the common way to route around blocks) — see `src/config.rs:451-460`. That means the vast majority of real deployments, including Dum4G's own setup that originally requested fronting, never reach the branch fronting was added to, and it silently never triggers for them.

This wires a fronting attempt into the other branch too (`DC not in --dc-ip config`: CF Worker → CF proxy → upstream proxy → ...), right before the final direct TCP fallback. That TCP step is close to dead weight for anyone relying on CF/upstream in the first place — they're using those fallbacks because direct Telegram connectivity is blocked, so the plain TCP attempt is nearly guaranteed to time out (confirmed from a real user's log: 178 `TCP connect timed out` occurrences). Fronting targets the same DC IP (`runtime.fallback_ip(dc)`) with a spoofed SNI and has an actual chance of getting through SNI-based DPI where WS/CF/upstream all failed.

## Also fixed

While writing the regression test, found that `tests/outbound_call_sites.rs`'s `run_proxy_once()` built `Runtime::new()` directly without calling `.with_fronting(...)`, so `--fronting-domain` was silently a no-op in any test using that helper. Fixed alongside.

## Test plan
- [x] `cargo test` — all existing tests + 1 new regression test (`proxy_tries_fronting_before_tcp_fallback_when_dc_ip_is_unconfigured`, verifies a fronting attempt happens before the TCP fallback via a rejecting outbound-proxy mock counting CONNECT requests)
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt`

Related to #81. Complements #88 (pool liveness check) — that PR fixes stale pooled connections; this one makes the fronting fallback actually reachable for non-`--dc-ip` setups like the one in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)