### PR TITLE
fix: match upstream CF-retry behavior; confine fronting to --dc-ip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ tg-ws-proxy [OPTIONS]
 | `--cf-balance` | off | Round-robin load balance across multiple `--cf-domain` and `--cf-worker-domain` values (see [CF Proxy](#cloudflare-proxy)) |
 | `--fronting-domain <DOMAIN>` | off | Domain-fronting fallback SNI, e.g. `sprinthost.ru` (see [Domain fronting](#domain-fronting)) |
 | `--fronting-cooldown <SECS>` | `1800` | How long the fronting fallback stays active after it last succeeded |
+| `--fronting-fail-cooldown <SECS>` | `60` | How long to stop retrying fronting after it fails for a DC (protects against networks that block Telegram's DC IPs outright, where fronting can never succeed) |
 | `--max-connections <N>` | auto | Max concurrent client connections (auto-computed from `ulimit -n`) |
 | `--mtproto-proxy <HOST:PORT:SECRET>` | — | Upstream MTProto proxy fallback (repeatable) |
 | `--outbound-proxy <URL>` | — | Proxy for all outgoing connections: `http://`, `socks5://`, or `socks5h://`; `https://` proxy URLs are not supported |
@@ -122,7 +123,7 @@ Every flag has a matching environment variable (`TG_PORT`, `TG_HOST`,
 `TG_VERBOSE`, `TG_SKIP_TLS_VERIFY`, `TG_LINK_IP`, `TG_LISTEN_FAKETLS_DOMAIN`, `TG_MTPROTO_PROXY`,
 `TG_LOG_FILE`, `TG_CF_DOMAIN`, `TG_CF_WORKER_DOMAIN`, `TG_CF_PRIORITY`,
 `TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`, `TG_OUTBOUND_PROXY`, `TG_NO_OUTBOUND_PROXY`, `TG_NO_PROXY`,
-`TG_FRONTING_DOMAIN`, `TG_FRONTING_COOLDOWN`).
+`TG_FRONTING_DOMAIN`, `TG_FRONTING_COOLDOWN`, `TG_FRONTING_FAIL_COOLDOWN`).
 When `TG_OUTBOUND_PROXY` is not set, standard `HTTPS_PROXY`, `ALL_PROXY`,
 `HTTP_PROXY` and `NO_PROXY` environment variables are also honored. `https://`
 proxy URLs are skipped when discovered from the standard environment if a later
@@ -350,6 +351,10 @@ The proxy will try the CF path as a fallback after direct WebSocket fails.
 With `--cf-priority`, the CF proxy is tried **before** direct WebSocket for all
 DCs.
 
+Every connection retries every configured CF domain fresh — a failure isn't
+remembered across connections (matching upstream tg-ws-proxy), so one flaky
+domain can never block the others, or the whole DC, from being tried.
+
 #### `--cf-balance` — round-robin load balancing
 
 When multiple `--cf-domain` values are given, connections normally always start
@@ -442,14 +447,28 @@ the HTTP `Host`. DPI that filters by SNI sees the fronted name; the actual
 (TLS-encrypted) request still reaches Telegram normally.
 
 ```bash
-tg-ws-proxy --fronting-domain sprinthost.ru
+tg-ws-proxy --dc-ip 2:149.154.167.220 --fronting-domain sprinthost.ru
 ```
+
+**Only takes effect when `--dc-ip` is configured for a DC** — this matches
+upstream tg-ws-proxy exactly: fronting is purely a direct-connection
+technique and is never applied to CF proxy, CF Worker, or upstream MTProto
+proxy connections (see their respective sections below). If you rely solely
+on `--cf-domain`/`--default-domains` — the common way to route around a
+block, and what suppresses the built-in `--dc-ip` default (see the
+`--dc-ip` row above) — `--fronting-domain` has no effect, by design.
+Upstream's own guidance for a network that blocks Telegram's IPs outright
+(where fronting can't help either, since it still needs a real TCP
+connection to that IP) is to leave `--dc-ip` unset entirely.
 
 Disabled unless `--fronting-domain` is set. Once a fronted connection
 succeeds, the fallback stays active (including for background connection-pool
 refills) for `--fronting-cooldown` seconds (default 1800 = 30 min), so the
 proxy doesn't keep re-probing the likely-still-blocked direct path on every
-new connection.
+new connection. If a fronting attempt fails, `--fronting-fail-cooldown`
+seconds (default 60) pass before it's retried for that DC — otherwise a
+network where fronting can never succeed (e.g. the DC IP itself is blocked)
+would pay for a doomed attempt on every single connection.
 
 > **Note:** TLS certificate verification is unconditionally skipped on
 > connections using this fallback, regardless of

--- a/src/config.rs
+++ b/src/config.rs
@@ -333,6 +333,16 @@ pub struct Config {
     /// only the SNI is swapped for this unrelated, presumably-unblocked
     /// domain, e.g. `sprinthost.ru` (the value upstream tg-ws-proxy uses).
     ///
+    /// **Only takes effect when `--dc-ip` is configured for that DC** — by
+    /// design, matching upstream tg-ws-proxy exactly: fronting only ever
+    /// applies to a direct connection to Telegram's real DC IP, never to the
+    /// CF proxy/Worker/upstream-proxy paths. If you rely solely on
+    /// `--cf-domain`/`--default-domains` (no `--dc-ip`), this flag has no
+    /// effect — upstream's own troubleshooting guidance for a network where
+    /// Telegram's IPs are blocked outright (where fronting can't help, since
+    /// it still needs a real TCP connection to that IP) is to leave
+    /// `--dc-ip` unset entirely so this path is never attempted.
+    ///
     /// Disabled unless set. TLS certificate verification is unconditionally
     /// skipped on connections using this fallback: the real Telegram
     /// certificate can never match a fronted SNI, so hostname verification
@@ -352,6 +362,21 @@ pub struct Config {
         env = "TG_FRONTING_COOLDOWN"
     )]
     pub fronting_cooldown: u64,
+
+    /// Seconds to stop retrying the domain-fronting fallback after it fails.
+    ///
+    /// Fronting only helps against SNI-based DPI blocking — it does nothing
+    /// for a network that blocks Telegram's DC IPs outright (the fronted
+    /// attempt still has to open a real TCP connection to that IP). Without
+    /// this cooldown, every connection to that DC would retry fronting from
+    /// scratch and pay a full `--ws-connect-timeout` for a doomed attempt on
+    /// top of the already doomed direct/CF/upstream/TCP attempts.
+    #[arg(
+        long = "fronting-fail-cooldown",
+        default_value = "60",
+        env = "TG_FRONTING_FAIL_COOLDOWN"
+    )]
+    pub fronting_fail_cooldown: u64,
 
     /// Maximum age of a pooled WebSocket connection in seconds.
     /// Connections older than this are discarded and re-established.

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,10 +254,20 @@ async fn main() {
     }
 
     if let Some(domain) = runtime.fronting_domain() {
-        info!(
-            "  Domain fronting: enabled (SNI {}, sticky for {}s after success)",
-            domain, config.fronting_cooldown
-        );
+        if dc_redirects.is_empty() {
+            warn!(
+                "  ⚠  --fronting-domain {} has no effect: no --dc-ip is configured. \
+                 Fronting only applies to a direct connection to a DC's real IP \
+                 (matching upstream tg-ws-proxy) — it is never used for CF proxy, \
+                 CF Worker, or upstream MTProto proxy connections.",
+                domain
+            );
+        } else {
+            info!(
+                "  Domain fronting: enabled (SNI {}, sticky for {}s after success)",
+                domain, config.fronting_cooldown
+            );
+        }
     }
 
     info!(

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -144,35 +144,10 @@ fn balanced_cf_workers(cf_worker_domains: &[String]) -> Vec<String> {
     result
 }
 
-/// Per-DC cooldown for the CF proxy path.
-static CF_FAIL_UNTIL: StdMutex<Option<HashMap<(u32, bool), Instant>>> = StdMutex::new(None);
 /// Per-Worker cooldown for the Cloudflare Worker path.
 static CF_WORKER_FAIL_UNTIL: StdMutex<Option<HashMap<String, Instant>>> = StdMutex::new(None);
 type TcpReader = ReadHalf<TcpStream>;
 type TcpWriter = WriteHalf<TcpStream>;
-
-fn set_cf_cooldown(dc: u32, is_media: bool, cooldown: Duration) {
-    let mut lock = CF_FAIL_UNTIL.lock().unwrap();
-    lock.get_or_insert_with(HashMap::new)
-        .insert((dc, is_media), Instant::now() + cooldown);
-}
-
-fn clear_cf_cooldown(dc: u32, is_media: bool) {
-    let mut lock = CF_FAIL_UNTIL.lock().unwrap();
-    if let Some(map) = lock.as_mut() {
-        map.remove(&(dc, is_media));
-    }
-}
-
-fn cf_in_cooldown(dc: u32, is_media: bool) -> bool {
-    let lock = CF_FAIL_UNTIL.lock().unwrap();
-    if let Some(map) = lock.as_ref()
-        && let Some(&until) = map.get(&(dc, is_media))
-    {
-        return Instant::now() < until;
-    }
-    false
-}
 
 fn set_cf_worker_cooldown(worker_domain: &str, cooldown: Duration) {
     let mut lock = CF_WORKER_FAIL_UNTIL.lock().unwrap();
@@ -191,6 +166,38 @@ fn cf_worker_in_cooldown(worker_domain: &str) -> bool {
     let lock = CF_WORKER_FAIL_UNTIL.lock().unwrap();
     if let Some(map) = lock.as_ref()
         && let Some(&until) = map.get(worker_domain)
+    {
+        return Instant::now() < until;
+    }
+    false
+}
+
+// ─── Domain-fronting failure tracking ────────────────────────────────────────
+
+/// Per-DC cooldown for a *failed* fronting attempt — distinct from
+/// `Runtime`'s sticky "fronting is currently working" state. Without this,
+/// a network that blocks Telegram's DC IPs outright (not just by SNI) would
+/// retry a doomed fronting attempt on every single connection; see
+/// `Config::fronting_fail_cooldown`.
+static FRONTING_FAIL_UNTIL: StdMutex<Option<HashMap<(u32, bool), Instant>>> = StdMutex::new(None);
+
+fn set_fronting_fail_cooldown(dc: u32, is_media: bool, cooldown: Duration) {
+    let mut lock = FRONTING_FAIL_UNTIL.lock().unwrap();
+    lock.get_or_insert_with(HashMap::new)
+        .insert((dc, is_media), Instant::now() + cooldown);
+}
+
+fn clear_fronting_fail_cooldown(dc: u32, is_media: bool) {
+    let mut lock = FRONTING_FAIL_UNTIL.lock().unwrap();
+    if let Some(map) = lock.as_mut() {
+        map.remove(&(dc, is_media));
+    }
+}
+
+fn fronting_in_fail_cooldown(dc: u32, is_media: bool) -> bool {
+    let lock = FRONTING_FAIL_UNTIL.lock().unwrap();
+    if let Some(map) = lock.as_ref()
+        && let Some(&until) = map.get(&(dc, is_media))
     {
         return Instant::now() < until;
     }
@@ -396,6 +403,7 @@ pub async fn handle_client_with_runtime(
     let upstream_fail_cooldown = Duration::from_secs(config.upstream_fail_cooldown);
     let cf_connect_timeout = Duration::from_secs(config.cf_connect_timeout);
     let cf_fail_cooldown = Duration::from_secs(config.cf_fail_cooldown);
+    let fronting_fail_cooldown = Duration::from_secs(config.fronting_fail_cooldown);
 
     // Split into independent read / write halves.
     let (mut reader, mut writer) = tokio::io::split(stream);
@@ -566,62 +574,57 @@ pub async fn handle_client_with_runtime(
         }
 
         // ── Try Cloudflare proxy if configured ────────────────────────────
+        // Always attempted fresh — no per-DC cooldown here, matching
+        // upstream's `_cfproxy_fallback`, which retries every configured
+        // domain on every single connection with no failure memory at all.
+        // A per-DC cooldown (removed) meant one flaky domain among many
+        // (e.g. with --cf-balance/--default-domains) blocked *all* of them
+        // for the whole cooldown window, forcing every connection in that
+        // window down into the fronting/TCP fallback instead.
         if !config.cf_domains.is_empty() {
-            if !cf_in_cooldown(dc_id, is_media) {
-                let cf_domains_for_conn = if config.cf_balance {
-                    balanced_cf_domains(&config.cf_domains)
-                } else {
-                    config.cf_domains.clone()
-                };
-                debug!(
-                    "[{}] DC{}{} {} → trying CF proxy via {:?}",
-                    label, dc_id, media_tag, reason, cf_domains_for_conn
-                );
+            let cf_domains_for_conn = if config.cf_balance {
+                balanced_cf_domains(&config.cf_domains)
+            } else {
+                config.cf_domains.clone()
+            };
+            debug!(
+                "[{}] DC{}{} {} → trying CF proxy via {:?}",
+                label, dc_id, media_tag, reason, cf_domains_for_conn
+            );
 
-                let (cf_ws_opt, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
-                    dc_id,
-                    &cf_domains_for_conn,
-                    is_media,
-                    skip_tls,
-                    cf_connect_timeout,
-                    runtime.outbound(),
+            let (cf_ws_opt, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
+                dc_id,
+                &cf_domains_for_conn,
+                is_media,
+                skip_tls,
+                cf_connect_timeout,
+                runtime.outbound(),
+            )
+            .await;
+
+            if let Some(ws) = cf_ws_opt {
+                info!(
+                    "[{}] DC{}{} {} → CF proxy connected",
+                    label, dc_id, media_tag, reason
+                );
+                bridge_ws(
+                    reader,
+                    writer,
+                    WsBridgeParams {
+                        label: &label,
+                        ws,
+                        relay_init,
+                        ciphers,
+                        proto,
+                        dc: dc_id,
+                        is_media,
+                    },
                 )
                 .await;
-
-                if let Some(ws) = cf_ws_opt {
-                    clear_cf_cooldown(dc_id, is_media);
-                    info!(
-                        "[{}] DC{}{} {} → CF proxy connected",
-                        label, dc_id, media_tag, reason
-                    );
-                    bridge_ws(
-                        reader,
-                        writer,
-                        WsBridgeParams {
-                            label: &label,
-                            ws,
-                            relay_init,
-                            ciphers,
-                            proto,
-                            dc: dc_id,
-                            is_media,
-                        },
-                    )
-                    .await;
-                    return;
-                } else {
-                    set_cf_cooldown(dc_id, is_media, cf_fail_cooldown);
-                    warn!(
-                        "[{}] DC{}{} CF proxy failed, cooldown {}s",
-                        label,
-                        dc_id,
-                        media_tag,
-                        cf_fail_cooldown.as_secs()
-                    );
-                }
+                return;
             } else {
-                debug!(
-                    "[{}] DC{}{} CF proxy in cooldown, skipping",
+                warn!(
+                    "[{}] DC{}{} CF proxy failed (all configured domains)",
                     label, dc_id, media_tag
                 );
             }
@@ -748,62 +751,52 @@ pub async fn handle_client_with_runtime(
     let ws_timeout = ws_timeout_for(dc_id, is_media, ws_connect_timeout, ws_fail_probe_timeout);
 
     // ── Step 6: CF priority — try CF proxy before direct WS if enabled ──
+    // No per-DC cooldown gate — see the note on the other CF proxy attempt
+    // below for why (matches upstream's memoryless per-connection retry).
     if config.cf_priority && !config.cf_domains.is_empty() {
-        if !cf_in_cooldown(dc_id, is_media) {
-            let cf_domains_for_conn = if config.cf_balance {
-                balanced_cf_domains(&config.cf_domains)
-            } else {
-                config.cf_domains.clone()
-            };
-            debug!(
-                "[{}] DC{}{} cf-priority → trying CF proxy first",
+        let cf_domains_for_conn = if config.cf_balance {
+            balanced_cf_domains(&config.cf_domains)
+        } else {
+            config.cf_domains.clone()
+        };
+        debug!(
+            "[{}] DC{}{} cf-priority → trying CF proxy first",
+            label, dc_id, media_tag
+        );
+
+        let (cf_ws_opt, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
+            dc_id,
+            &cf_domains_for_conn,
+            is_media,
+            skip_tls,
+            cf_connect_timeout,
+            runtime.outbound(),
+        )
+        .await;
+
+        if let Some(ws) = cf_ws_opt {
+            info!(
+                "[{}] DC{}{} → CF proxy connected (priority)",
                 label, dc_id, media_tag
             );
-
-            let (cf_ws_opt, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
-                dc_id,
-                &cf_domains_for_conn,
-                is_media,
-                skip_tls,
-                cf_connect_timeout,
-                runtime.outbound(),
+            bridge_ws(
+                reader,
+                writer,
+                WsBridgeParams {
+                    label: &label,
+                    ws,
+                    relay_init,
+                    ciphers,
+                    proto,
+                    dc: dc_id,
+                    is_media,
+                },
             )
             .await;
-
-            if let Some(ws) = cf_ws_opt {
-                clear_cf_cooldown(dc_id, is_media);
-                info!(
-                    "[{}] DC{}{} → CF proxy connected (priority)",
-                    label, dc_id, media_tag
-                );
-                bridge_ws(
-                    reader,
-                    writer,
-                    WsBridgeParams {
-                        label: &label,
-                        ws,
-                        relay_init,
-                        ciphers,
-                        proto,
-                        dc: dc_id,
-                        is_media,
-                    },
-                )
-                .await;
-                return;
-            } else {
-                set_cf_cooldown(dc_id, is_media, cf_fail_cooldown);
-                warn!(
-                    "[{}] DC{}{} CF proxy failed (priority), cooldown {}s — falling back to WS",
-                    label,
-                    dc_id,
-                    media_tag,
-                    cf_fail_cooldown.as_secs()
-                );
-            }
+            return;
         } else {
-            debug!(
-                "[{}] DC{}{} CF proxy in cooldown (priority), trying WS",
+            warn!(
+                "[{}] DC{}{} CF proxy failed (priority) — falling back to WS",
                 label, dc_id, media_tag
             );
         }
@@ -844,6 +837,7 @@ pub async fn handle_client_with_runtime(
 
         if let Some(domain) = sticky_fronting_domain {
             if ws_opt.is_some() {
+                clear_fronting_fail_cooldown(dc_id, is_media);
                 runtime.activate_fronting();
                 info!(
                     "[{}] DC{}{} → fronting connected (SNI {})",
@@ -851,9 +845,13 @@ pub async fn handle_client_with_runtime(
                 );
             } else {
                 runtime.deactivate_fronting();
+                set_fronting_fail_cooldown(dc_id, is_media, fronting_fail_cooldown);
                 warn!(
-                    "[{}] DC{}{} fronting (sticky) failed, falling back",
-                    label, dc_id, media_tag
+                    "[{}] DC{}{} fronting (sticky) failed, falling back, cooldown {}s",
+                    label,
+                    dc_id,
+                    media_tag,
+                    fronting_fail_cooldown.as_secs()
                 );
             }
         } else if ws_opt.is_some() {
@@ -863,11 +861,17 @@ pub async fn handle_client_with_runtime(
                 "[{}] DC{}{} → WS connected via {}",
                 label, dc_id, media_tag, target_ip
             );
-        } else if timed_out && let Some(domain) = runtime.fronting_domain() {
+        } else if timed_out
+            && !fronting_in_fail_cooldown(dc_id, is_media)
+            && let Some(domain) = runtime.fronting_domain()
+        {
             // Reactive fronting: the normal (non-fronted) attempt above
             // timed out — a sign of SNI-based DPI blocking — so try once
             // more with the fronted SNI before falling back to cooldown +
-            // CF/upstream/TCP.
+            // CF/upstream/TCP. Skipped while a previous fronting attempt is
+            // in its own fail-cooldown — a network that blocks the DC IP
+            // outright would otherwise pay for this doomed attempt on every
+            // single connection (see `fronting_fail_cooldown` docs).
             info!(
                 "[{}] DC{}{} WS timed out → trying fronting (SNI {})",
                 label, dc_id, media_tag, domain
@@ -885,15 +889,20 @@ pub async fn handle_client_with_runtime(
             .await;
 
             if front_opt.is_some() {
+                clear_fronting_fail_cooldown(dc_id, is_media);
                 runtime.activate_fronting();
                 info!(
                     "[{}] DC{}{} → fronting connected (SNI {})",
                     label, dc_id, media_tag, domain
                 );
             } else {
+                set_fronting_fail_cooldown(dc_id, is_media, fronting_fail_cooldown);
                 warn!(
-                    "[{}] DC{}{} fronting fallback failed",
-                    label, dc_id, media_tag
+                    "[{}] DC{}{} fronting fallback failed, cooldown {}s",
+                    label,
+                    dc_id,
+                    media_tag,
+                    fronting_fail_cooldown.as_secs()
                 );
             }
             ws_opt = front_opt;
@@ -993,59 +1002,49 @@ pub async fn handle_client_with_runtime(
 
                 // ── Try Cloudflare proxy if configured ────────────────────
                 // (Skip if --cf-priority already tried the CF path above.)
+                // No per-DC cooldown gate here either — see the note on the
+                // other CF proxy attempt above.
                 if !config.cf_priority && !config.cf_domains.is_empty() {
-                    if !cf_in_cooldown(dc_id, is_media) {
-                        let cf_domains_for_conn = if config.cf_balance {
-                            balanced_cf_domains(&config.cf_domains)
-                        } else {
-                            config.cf_domains.clone()
-                        };
-                        debug!(
-                            "[{}] DC{}{} WS/Worker failed → trying CF proxy",
-                            label, dc_id, media_tag
-                        );
+                    let cf_domains_for_conn = if config.cf_balance {
+                        balanced_cf_domains(&config.cf_domains)
+                    } else {
+                        config.cf_domains.clone()
+                    };
+                    debug!(
+                        "[{}] DC{}{} WS/Worker failed → trying CF proxy",
+                        label, dc_id, media_tag
+                    );
 
-                        let (cf_ws_opt, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
-                            dc_id,
-                            &cf_domains_for_conn,
-                            is_media,
-                            skip_tls,
-                            cf_connect_timeout,
-                            runtime.outbound(),
+                    let (cf_ws_opt, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
+                        dc_id,
+                        &cf_domains_for_conn,
+                        is_media,
+                        skip_tls,
+                        cf_connect_timeout,
+                        runtime.outbound(),
+                    )
+                    .await;
+
+                    if let Some(ws) = cf_ws_opt {
+                        info!("[{}] DC{}{} → CF proxy connected", label, dc_id, media_tag);
+                        bridge_ws(
+                            reader,
+                            writer,
+                            WsBridgeParams {
+                                label: &label,
+                                ws,
+                                relay_init,
+                                ciphers,
+                                proto,
+                                dc: dc_id,
+                                is_media,
+                            },
                         )
                         .await;
-
-                        if let Some(ws) = cf_ws_opt {
-                            clear_cf_cooldown(dc_id, is_media);
-                            info!("[{}] DC{}{} → CF proxy connected", label, dc_id, media_tag);
-                            bridge_ws(
-                                reader,
-                                writer,
-                                WsBridgeParams {
-                                    label: &label,
-                                    ws,
-                                    relay_init,
-                                    ciphers,
-                                    proto,
-                                    dc: dc_id,
-                                    is_media,
-                                },
-                            )
-                            .await;
-                            return;
-                        } else {
-                            set_cf_cooldown(dc_id, is_media, cf_fail_cooldown);
-                            warn!(
-                                "[{}] DC{}{} CF proxy failed, cooldown {}s",
-                                label,
-                                dc_id,
-                                media_tag,
-                                cf_fail_cooldown.as_secs()
-                            );
-                        }
+                        return;
                     } else {
-                        debug!(
-                            "[{}] DC{}{} CF proxy in cooldown, skipping",
+                        warn!(
+                            "[{}] DC{}{} CF proxy failed (all configured domains)",
                             label, dc_id, media_tag
                         );
                     }
@@ -1971,5 +1970,25 @@ mod tests {
 
         clear_cf_worker_cooldown("w1.example.workers.dev");
         assert!(!cf_worker_in_cooldown("w1.example.workers.dev"));
+    }
+
+    #[test]
+    fn fronting_fail_cooldown_is_tracked_per_dc_and_media_flag() {
+        // Use DC numbers not touched by other tests in this file (which run
+        // concurrently and share this same global static).
+        clear_fronting_fail_cooldown(90, false);
+        clear_fronting_fail_cooldown(90, true);
+
+        assert!(!fronting_in_fail_cooldown(90, false));
+        assert!(!fronting_in_fail_cooldown(90, true));
+
+        set_fronting_fail_cooldown(90, false, Duration::from_secs(60));
+        assert!(fronting_in_fail_cooldown(90, false));
+        // The media flag is part of the key — a non-media cooldown must not
+        // leak into the media bucket for the same DC.
+        assert!(!fronting_in_fail_cooldown(90, true));
+
+        clear_fronting_fail_cooldown(90, false);
+        assert!(!fronting_in_fail_cooldown(90, false));
     }
 }

--- a/tests/outbound_call_sites.rs
+++ b/tests/outbound_call_sites.rs
@@ -259,6 +259,56 @@ async fn proxy_tcp_fallback_uses_outbound_proxy() {
     assert!(request.starts_with("CONNECT 149.154.167.51:443 HTTP/1.1"));
 }
 
+#[tokio::test]
+async fn cf_proxy_is_retried_fresh_on_every_connection_no_cooldown() {
+    // Regression test for issue #81: a per-DC cooldown used to block *every*
+    // CF domain for a DC after a single failed attempt, so with
+    // --cf-balance/--default-domains (many domains) one flaky domain could
+    // knock out CF entirely for --cf-fail-cooldown seconds, forcing every
+    // connection in that window straight to the (often doomed) TCP fallback.
+    // Upstream tg-ws-proxy's `_cfproxy_fallback` has no such cooldown at
+    // all — every connection retries every configured domain fresh — so we
+    // now match that. With one CF domain configured (2 domain variants:
+    // kwsN and kwsN-1) and no --dc-ip/upstream-proxy, each of 2 separate
+    // client connections should independently try both CF domain variants
+    // before falling through to TCP: 3 CONNECTs per connection, 6 total.
+    // The old cooldown-gated behavior would only produce 4 (connection 2
+    // skips CF and goes straight to its single TCP-fallback attempt).
+    let (proxy_addr, proxy_task) = rejecting_http_proxy_requests(6).await;
+    let make_config = || {
+        Config::try_parse_from([
+            "tg-ws-proxy",
+            "--secret",
+            "00112233445566778899aabbccddeeff",
+            "--cf-domain",
+            "example.net",
+            "--outbound-proxy",
+            &format!("http://{proxy_addr}"),
+            "--no-outbound-proxy",
+            "--no-proxy",
+            "",
+            "--handshake-timeout",
+            "2",
+            "--cf-connect-timeout",
+            "2",
+            "--tcp-fallback-timeout",
+            "2",
+        ])
+        .unwrap()
+    };
+
+    run_proxy_once(make_config()).await;
+    run_proxy_once(make_config()).await;
+
+    let requests = await_proxy_requests(proxy_task).await;
+    assert_eq!(
+        requests.len(),
+        6,
+        "expected both connections to retry CF fresh (2 domains + TCP \
+         fallback each), got {requests:?}"
+    );
+}
+
 async fn rejecting_http_proxy() -> (std::net::SocketAddr, tokio::task::JoinHandle<String>) {
     let (addr, task) = rejecting_http_proxy_requests(1).await;
     let task = tokio::spawn(async move { await_proxy_requests(task).await.remove(0) });
@@ -350,9 +400,19 @@ async fn read_http_connect_request(stream: &mut TcpStream) -> String {
 }
 
 async fn run_proxy_once(config: Config) {
+    run_proxy_once_for_dc(config, 2).await;
+}
+
+/// Same as [`run_proxy_once`], but lets the caller pick the DC so tests that
+/// touch DC-keyed global cooldown state (e.g. the fronting fail-cooldown)
+/// don't collide with other tests sharing the same test binary process.
+async fn run_proxy_once_for_dc(config: Config, dc: i16) {
     let secret = config.secret_bytes();
     let outbound = config.outbound_connector().unwrap();
-    let runtime = Arc::new(Runtime::new(outbound));
+    let runtime = Arc::new(Runtime::new(outbound).with_fronting(
+        config.fronting_domain.clone(),
+        Duration::from_secs(config.fronting_cooldown),
+    ));
     let pool = Arc::new(WsPool::with_runtime(
         0,
         Duration::from_secs(config.pool_max_age),
@@ -370,7 +430,7 @@ async fn run_proxy_once(config: Config) {
     let proxy_task = tokio::spawn(handle_client_with_runtime(
         server, peer, config, pool, runtime,
     ));
-    let (handshake, _, _) = generate_client_handshake(&secret, 2, ProtoTag::PaddedIntermediate);
+    let (handshake, _, _) = generate_client_handshake(&secret, dc, ProtoTag::PaddedIntermediate);
     client.write_all(&handshake).await.unwrap();
     drop(client);
 


### PR DESCRIPTION
## Summary

Supersedes #89 (closing it in favor of this). Re-verified against upstream tg-ws-proxy's actual source — `bridge.py`, `tg_ws_proxy.py`, `balancer.py`, and the v1.8.0 release notes — not just the single "Fronting fallback" commit I'd looked at before. Issue #81's later reports (after #88/#89 landed) showed our port had drifted from upstream in two concrete ways:

**1. Fronting is confined to `--dc-ip` connections in upstream, full stop.** It's applied only to a direct connection to a DC's real IP, gated behind that DC having a known IP. `Config::from_args()` already suppresses the default `--dc-ip` (DC2/4) specifically when `--cf-domain`/`--default-domains` is set, so CF becomes the *only* path — and upstream's own v1.8.0 release notes document that the fix for "fronting failed: TimeoutError" + "WS connect timed out" is to **clear `--dc-ip`** so fronting is never attempted, not to make it reachable without one. #89 did the opposite. Reverted; `--fronting-domain` is now clearly documented as requiring `--dc-ip`, with a startup warning if it's set without effect.

**2. Our per-DC CF-proxy cooldown had no upstream equivalent, and was the actual root cause of the "DC2 loops into TCP" reports.** Upstream's `_cfproxy_fallback` retries every configured domain fresh on every single connection — no failure memory at all (`balancer.py` only remembers the last *successful* domain as a "try this first" hint, never blocks anything). Our `--cf-fail-cooldown` blocked **all** domains for a DC for 60s after any single failure, so with `--cf-balance`/`--default-domains` (many domains), one flaky domain was enough to knock out CF entirely for a full minute — forcing every connection in that window into the fronting/TCP fallback instead. Removed the cooldown gate from all three CF-proxy call sites.

The fronting fail-cooldown from #89 (don't retry a *failed* fronting attempt on every connection) is legitimate and kept, just scoped back to the two `--dc-ip` call sites it was always meant for.

## Test plan
- [x] `cargo test` — all tests pass (3x, no flakiness), plus:
  - new: `cf_proxy_is_retried_fresh_on_every_connection_no_cooldown` (2 separate connections both retry CF fully — proves no cross-connection cooldown)
  - new: `fronting_fail_cooldown_is_tracked_per_dc_and_media_flag` (unit test for the retained cooldown mechanism)
  - fixed a pre-existing test-infra gap: `run_proxy_once` never wired `--fronting-domain` into `Runtime` at all
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt`
- [x] Manually ran the proxy (release build) against a real connected Telegram client for the CF path — connects fine, correct startup warning appears when `--fronting-domain` is set without `--dc-ip`

Fixes/supersedes work on #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)