### PR TITLE
fix: don't use 64-bit atomics, they don't exist on 32-bit MIPS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use cipher::StreamCipher;
@@ -1552,26 +1552,31 @@ impl ClosedBy {
 /// task's return value is gone. Accumulating inside the task meant every
 /// session logged exactly one direction as zero — 136 of 137 sessions in one
 /// tester's log — which made the counts useless for diagnosing anything.
+///
+/// Deliberately a `Mutex<u64>` per direction rather than an atomic: 32-bit
+/// MIPS — one of this project's release targets — has no 64-bit atomics at
+/// all, and `AtomicUsize` there would silently wrap a direction at 4 GiB,
+/// which is exactly the "the numbers lie" problem this type exists to fix.
+/// Each counter has a single writer and is read once the session is over, so
+/// the lock is always uncontended: a few tens of nanoseconds per 16 KiB
+/// chunk, against the AES pass over those same bytes.
 #[derive(Default)]
 struct BridgeCounters {
-    up: AtomicU64,
-    down: AtomicU64,
+    up: StdMutex<u64>,
+    down: StdMutex<u64>,
 }
 
 impl BridgeCounters {
     fn add_up(&self, n: usize) {
-        self.up.fetch_add(n as u64, Ordering::Relaxed);
+        *self.up.lock().unwrap() += n as u64;
     }
 
     fn add_down(&self, n: usize) {
-        self.down.fetch_add(n as u64, Ordering::Relaxed);
+        *self.down.lock().unwrap() += n as u64;
     }
 
     fn totals(&self) -> (u64, u64) {
-        (
-            self.up.load(Ordering::Relaxed),
-            self.down.load(Ordering::Relaxed),
-        )
+        (*self.up.lock().unwrap(), *self.down.lock().unwrap())
     }
 }
 


### PR DESCRIPTION
Fixes the release build for `mips-unknown-linux-musl` and `mipsel-unknown-linux-musl`, broken by #92:

```
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
  --> src/proxy.rs:29:25
   |
29 | use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
   |                         ^^^^^^^^^ no `AtomicU64` in `sync::atomic`
```

MIPS32 has no 64-bit atomic instructions, so `AtomicU64` simply does not exist on those targets.

## Why not `AtomicUsize`

It compiles, but it is 32-bit on MIPS, so a session direction carrying more than 4 GiB would wrap silently — which is the exact "the byte counts lie" problem `BridgeCounters` was added in #92 to fix.

## What it does instead

A `Mutex<u64>` per direction. Each counter has exactly one writer, and is read only once the session has ended, so the lock is always uncontended — a few tens of nanoseconds per 16 KiB chunk, against the AES pass already being done over those same bytes. Exact on every target, no new dependency.

## Note on CI

This class of break is invisible until a tag is pushed: `ci.yml` builds host-only, and MIPS is compiled solely by `release.yml` (nightly + `cross` + `-Z build-std`). Worth considering a `cargo check` for one 32-bit MIPS target in CI as a follow-up — `check` needs no linker, so it is much cheaper than the release build.

Version bumped to 1.7.1 as `release-version` requires. v1.7.0 was never tagged.
