### PR TITLE
fix: паритет Cloudflare-путей с апстримом v1.9.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,11 @@ the PR otherwise.
 
 - The MTProto transport and the WebSocket transport have different framing guarantees — see
   `splitter.rs`. Never assume one WebSocket message == one MTProto packet without going through
-  the splitter.
+  the splitter. The one exception is the Cloudflare **Worker** tunnel: its far end is a raw TCP
+  socket, so message boundaries mean nothing there and packet-aligning is actively harmful —
+  Cloudflare drops WebSocket messages over 1 MiB, which a media upload's MTProto packets exceed.
+  `proxy.rs`'s `WsFraming` is what keeps the two apart; add a new WebSocket upstream to the wrong
+  arm and uploads break only for large files.
 - `--host` auto-detection (`Config::bind_host`/`Config::link_host` in `config.rs`) intentionally
   keeps the bind address and the advertised `tg://` link address consistent. If you touch this
   logic, verify both by actually starting the binary (`cargo run -- --port <N>`) and reading the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "1.8.0"
+version = "2.0.0"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.8.0"
+version = "2.0.0"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -352,12 +352,16 @@ The proxy will try the CF path as a fallback after direct WebSocket fails.
 With `--cf-priority`, the Cloudflare tiers — the Worker tunnel first, then the
 CF proxy — are tried **before** direct WebSocket for all DCs.
 
-A `--dc-ip` address whose TCP connect *times out* is dropped from the direct
-path for `--ip-fail-cooldown` seconds (default one hour) whenever a fallback
-tier is configured, instead of costing every later connection another connect
-timeout. A refused or redirected connection does not count — only a timeout,
-which is what a DPI-blocked address looks like. The cooldown is cleared the
-moment a direct connection to that address succeeds again.
+A `--dc-ip` address whose TCP connect *times out* is stepped over for
+`--ip-fail-cooldown` seconds (default one hour) whenever a fallback tier is
+configured, instead of costing every later connection another connect timeout.
+A refused or redirected connection does not count — only a timeout, which is
+what a DPI-blocked address looks like, and only at the full connect timeout
+(not the short probe a DC in cooldown gets).
+
+Stepped over, not written off: if every fallback tier is also failing, the
+address is re-probed rather than leaving the client on raw TCP for the rest of
+the window, and the first direct connect that succeeds clears the cooldown.
 
 Every connection retries every configured CF domain fresh — a failure isn't
 remembered across connections (matching upstream tg-ws-proxy), so one flaky

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ tg-ws-proxy [OPTIONS]
 | `--cf-domain <DOMAIN>` | — | Cloudflare-proxied domain(s) for alternative WS routing, comma-separated (see [CF Proxy](#cloudflare-proxy)) |
 | `--cf-worker-domain <DOMAIN>` | — | Cloudflare Worker domain(s) for TCP-tunnel fallback, comma-separated/repeatable (see [Cloudflare Worker](#cloudflare-worker)) |
 | `--default-domains` | off | Fetch and use the built-in CF proxy domain list from GitHub (no Cloudflare setup needed, see [Default domains](#default-domains)) |
-| `--cf-priority` | off | Try CF proxy **before** direct WS for all DCs (see [CF Proxy](#cloudflare-proxy)) |
+| `--cf-priority` | off | Try the CF tiers (Worker, then CF proxy) **before** direct WS for all DCs (see [CF Proxy](#cloudflare-proxy)) |
 | `--cf-balance` | off | Round-robin load balance across multiple `--cf-domain` and `--cf-worker-domain` values (see [CF Proxy](#cloudflare-proxy)) |
+| `--ip-fail-cooldown <SECS>` | `3600` | How long to skip the direct WS path for a `--dc-ip` address whose TCP connect timed out, when a Cloudflare/upstream fallback is configured |
 | `--fronting-domain <DOMAIN>` | off | Domain-fronting fallback SNI, e.g. `sprinthost.ru` (see [Domain fronting](#domain-fronting)) |
 | `--fronting-cooldown <SECS>` | `1800` | How long the fronting fallback stays active after it last succeeded |
 | `--fronting-fail-cooldown <SECS>` | `60` | How long to stop retrying fronting after it fails for a DC (protects against networks that block Telegram's DC IPs outright, where fronting can never succeed) |
@@ -340,7 +341,7 @@ tg-ws-proxy --cf-domain primary.net,backup.com --cf-balance
 # CF-only mode: omit --dc-ip so CF proxy handles all DCs
 tg-ws-proxy --cf-domain yourdomain.com
 
-# CF priority: try CF proxy before direct WS, with WS as fallback
+# CF priority: try the CF tiers before direct WS, with WS as fallback
 tg-ws-proxy --dc-ip 2:149.154.167.220 --cf-domain yourdomain.com --cf-priority
 
 # Or via environment variable
@@ -348,8 +349,15 @@ TG_CF_DOMAIN=yourdomain.com tg-ws-proxy
 ```
 
 The proxy will try the CF path as a fallback after direct WebSocket fails.
-With `--cf-priority`, the CF proxy is tried **before** direct WebSocket for all
-DCs.
+With `--cf-priority`, the Cloudflare tiers — the Worker tunnel first, then the
+CF proxy — are tried **before** direct WebSocket for all DCs.
+
+A `--dc-ip` address whose TCP connect *times out* is dropped from the direct
+path for `--ip-fail-cooldown` seconds (default one hour) whenever a fallback
+tier is configured, instead of costing every later connection another connect
+timeout. A refused or redirected connection does not count — only a timeout,
+which is what a DPI-blocked address looks like. The cooldown is cleared the
+moment a direct connection to that address succeeds again.
 
 Every connection retries every configured CF domain fresh — a failure isn't
 remembered across connections (matching upstream tg-ws-proxy), so one flaky

--- a/docs/CfProxy.md
+++ b/docs/CfProxy.md
@@ -96,10 +96,15 @@ entirely and `--cf-domain` is set, CF proxy becomes the primary path for
 
 ### `--cf-priority`
 
-When `--cf-priority` is set, the CF proxy is tried **before** the normal
-direct WebSocket connection for **all** DCs (even those with `--dc-ip`
-configured).  If the CF proxy fails, the proxy falls back to the normal WS
-path, then upstream MTProto proxies, then direct TCP.
+When `--cf-priority` is set, the Cloudflare tiers are tried **before** the
+normal direct WebSocket connection for **all** DCs (even those with `--dc-ip`
+configured): the Worker tunnel first (`--cf-worker-domain`), then the CF proxy
+(`--cf-domain`).  If both fail, the proxy falls back to the normal WS path,
+then upstream MTProto proxies, then direct TCP.
+
+The flag covers a Worker-only setup too — with only `--cf-worker-domain`
+configured it used to do nothing at all, so every connection still waited out
+the direct-WS timeout before reaching the Worker.
 
 ```sh
 tg-ws-proxy --dc-ip 2:149.154.167.220 --cf-domain yourdomain.com --cf-priority

--- a/docs/CfWorker.md
+++ b/docs/CfWorker.md
@@ -47,6 +47,12 @@ TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev
 tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev --check
 ```
 
+Проверка не ограничивается WebSocket-апгрейдом: через туннель отправляется
+настоящий MTProto init, и если Worker не может достучаться до Telegram, туннель
+закроется сразу — `--check` покажет `FAIL`. Cloudflare отвечает `101` из самого
+кода Worker'а, ещё до того как его `connect()` до датацентра отработает, поэтому
+успешный апгрейд сам по себе ничего не доказывает.
+
 ### Код Worker'а
 ```javascript
 import { connect } from "cloudflare:sockets";

--- a/src/check.rs
+++ b/src/check.rs
@@ -143,10 +143,15 @@ async fn probe_cf_worker(
         return ProbeStatus::Fail(format!("Worker tunnel closed on send: {}", e));
     }
 
+    // Everything the user cares about timing has happened by now; the settle
+    // wait below is a fixed cost of the probe, not latency of the tunnel, and
+    // reporting it would make every healthy Worker look three seconds slow.
+    let elapsed = start.elapsed();
+
     // Anything arriving here is the tunnel dying: either a close frame, or a
     // stray payload from something on `dst:443` that is not a Telegram DC.
     match tokio::time::timeout(WORKER_TUNNEL_SETTLE, ws_recv(&mut ws)).await {
-        Err(_) => ProbeStatus::Ok(start.elapsed()),
+        Err(_) => ProbeStatus::Ok(elapsed),
         Ok(None) => ProbeStatus::Fail(format!(
             "Worker tunnel to {} closed immediately — the Worker cannot reach Telegram \
              (check its live logs in the Cloudflare dashboard)",

--- a/src/check.rs
+++ b/src/check.rs
@@ -13,6 +13,12 @@
 //! means Cloudflare is correctly routing the WebSocket traffic to Telegram's
 //! DC 2 server and the domain is usable by the proxy.
 //!
+//! **CF Worker** — The Worker's WebSocket tunnel to DC 2 is opened *and* a
+//! 64-byte MTProto init is pushed through it.  The upgrade on its own says
+//! nothing: the Worker returns `101` before its TCP `connect()` to Telegram is
+//! known to have worked, so only the init — and the silence that should follow
+//! it — proves the far end is really a DC.
+//!
 //! **MTProto proxy (plain / 0xdd)** — A TCP connection is made and the
 //! 64-byte MTProto obfuscation handshake is sent.  A successful send verifies
 //! the proxy is reachable at the network level.
@@ -31,7 +37,7 @@ use crate::crypto::{self, ProtoTag, generate_client_handshake};
 use crate::faketls;
 use crate::outbound::OutboundConnector;
 use crate::ws_client::{
-    connect_cf_worker_ws_for_dc_with_outbound, connect_cf_ws_for_dc_with_outbound,
+    connect_cf_worker_ws_for_dc_with_outbound, connect_cf_ws_for_dc_with_outbound, ws_recv, ws_send,
 };
 
 // ─── Probe result ─────────────────────────────────────────────────────────────
@@ -75,7 +81,7 @@ async fn probe_cf_domain(
     outbound: &OutboundConnector,
 ) -> ProbeStatus {
     let start = Instant::now();
-    let (ws, _) = connect_cf_ws_for_dc_with_outbound(
+    let (ws, _record, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
         2,
         &[domain.to_string()],
         false,
@@ -93,7 +99,24 @@ async fn probe_cf_domain(
     }
 }
 
-/// Probe a Cloudflare Worker by opening its WebSocket tunnel to DC 2.
+/// How long the Worker probe waits for its tunnel to be torn down before
+/// calling it healthy.
+///
+/// Telegram answers the 64-byte init with silence — it only speaks once the
+/// client sends a request — so silence *is* the success signal here and the
+/// probe can only wait it out.  Long enough to cover a Worker round trip plus
+/// the DC handshake, short enough that `--check` stays interactive.
+const WORKER_TUNNEL_SETTLE: Duration = Duration::from_secs(3);
+
+/// Probe a Cloudflare Worker by opening its WebSocket tunnel to DC 2 and
+/// pushing a real MTProto init through it.
+///
+/// The WebSocket upgrade alone proves nothing about the tunnel: Cloudflare
+/// answers `101` from the Worker script itself, before — and regardless of
+/// whether — its `connect()` to the Telegram DC ever succeeds.  A Worker that
+/// cannot reach Telegram therefore passed this check while every real client
+/// through it died instantly (#93).  Sending the init and watching for a
+/// close is what tells the two apart.
 async fn probe_cf_worker(
     domain: &str,
     skip_tls: bool,
@@ -109,12 +132,32 @@ async fn probe_cf_worker(
         domain, dst, 2, false, skip_tls, timeout, outbound,
     )
     .await;
-    if ws.is_some() {
-        ProbeStatus::Ok(start.elapsed())
-    } else {
-        ProbeStatus::Fail(
+    let Some(mut ws) = ws else {
+        return ProbeStatus::Fail(
             "Worker WebSocket tunnel failed — check Worker code and domain".to_string(),
-        )
+        );
+    };
+
+    let relay_init = crypto::generate_relay_init(ProtoTag::Intermediate, 2);
+    if let Err(e) = ws_send(&mut ws, relay_init.to_vec()).await {
+        return ProbeStatus::Fail(format!("Worker tunnel closed on send: {}", e));
+    }
+
+    // Anything arriving here is the tunnel dying: either a close frame, or a
+    // stray payload from something on `dst:443` that is not a Telegram DC.
+    match tokio::time::timeout(WORKER_TUNNEL_SETTLE, ws_recv(&mut ws)).await {
+        Err(_) => ProbeStatus::Ok(start.elapsed()),
+        Ok(None) => ProbeStatus::Fail(format!(
+            "Worker tunnel to {} closed immediately — the Worker cannot reach Telegram \
+             (check its live logs in the Cloudflare dashboard)",
+            dst
+        )),
+        Ok(Some(data)) => ProbeStatus::Fail(format!(
+            "Worker tunnel to {} answered the MTProto init with {} unexpected bytes — \
+             the far end is not a Telegram DC",
+            dst,
+            data.len()
+        )),
     }
 }
 
@@ -269,7 +312,7 @@ pub async fn run_check_with_outbound(config: &Config, outbound: &OutboundConnect
     if !cf_worker_domains.is_empty() {
         println!();
         println!("Cloudflare Worker domains (DC2 TCP tunnel probe):");
-        for domain in &cf_worker_domains {
+        for domain in cf_worker_domains {
             print!("  {:40}  ... ", domain);
             let _ = std::io::Write::flush(&mut std::io::stdout());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,11 +258,12 @@ pub struct Config {
     )]
     pub cf_worker_domains: Vec<String>,
 
-    /// Prioritise Cloudflare proxy over direct WebSocket connections for all
-    /// DCs (even those with `--dc-ip` configured).
+    /// Prioritise the Cloudflare tiers over direct WebSocket connections for
+    /// all DCs (even those with `--dc-ip` configured).
     ///
-    /// When set, the proxy tries the CF path first; if it fails, falls back to
-    /// the normal WS path, then upstream MTProto proxies, then direct TCP.
+    /// When set, the proxy tries the Cloudflare Worker tunnel and then the
+    /// Cloudflare proxy first; if both fail, it falls back to the normal WS
+    /// path, then upstream MTProto proxies, then direct TCP.
     #[arg(long = "cf-priority", env = "TG_CF_PRIORITY")]
     pub cf_priority: bool,
 
@@ -317,12 +318,17 @@ pub struct Config {
     ///
     /// A timeout (rather than a refusal or a redirect) is what a DPI-blocked
     /// address looks like, and that does not lift within a connection's
-    /// lifetime — so the address is left alone for a long window and every
+    /// lifetime — so the address is stepped over for a long window and every
     /// client goes straight to the Cloudflare/upstream-proxy tiers instead of
-    /// paying `--ws-connect-timeout` first.  Only honored when such a fallback
-    /// is configured; the cooldown is dropped as soon as a direct connect to
-    /// that address succeeds again.  Matches upstream tg-ws-proxy's
-    /// `IP_FAIL_COOLDOWN`.
+    /// paying `--ws-connect-timeout` first.
+    ///
+    /// Stepped over, not written off: a connection that finds every fallback
+    /// tier dead re-probes the address anyway, and the first direct connect
+    /// that succeeds clears the cooldown — so a window opened by a passing
+    /// glitch cannot strand anyone.  The skipping needs a fallback tier to be
+    /// configured; the record itself is always kept, since the pool reads it
+    /// to stop pre-connecting into the same hole.  Matches upstream
+    /// tg-ws-proxy's `IP_FAIL_COOLDOWN`.
     #[arg(
         long = "ip-fail-cooldown",
         default_value = "3600",

--- a/src/config.rs
+++ b/src/config.rs
@@ -312,6 +312,24 @@ pub struct Config {
     )]
     pub ws_redirect_cooldown: u64,
 
+    /// Seconds to skip the direct WebSocket path for a `--dc-ip` address whose
+    /// TCP connect timed out.
+    ///
+    /// A timeout (rather than a refusal or a redirect) is what a DPI-blocked
+    /// address looks like, and that does not lift within a connection's
+    /// lifetime — so the address is left alone for a long window and every
+    /// client goes straight to the Cloudflare/upstream-proxy tiers instead of
+    /// paying `--ws-connect-timeout` first.  Only honored when such a fallback
+    /// is configured; the cooldown is dropped as soon as a direct connect to
+    /// that address succeeds again.  Matches upstream tg-ws-proxy's
+    /// `IP_FAIL_COOLDOWN`.
+    #[arg(
+        long = "ip-fail-cooldown",
+        default_value = "3600",
+        env = "TG_IP_FAIL_COOLDOWN"
+    )]
+    pub ip_fail_cooldown: u64,
+
     /// Client MTProto handshake read timeout in seconds.
     #[arg(
         long = "handshake-timeout",
@@ -484,6 +502,15 @@ impl Config {
     /// argument list — tests, or anything embedding the library — goes through
     /// exactly the same normalization the binary does.
     pub fn with_defaults(mut self) -> Self {
+        // Normalize the Worker domains once, so the routing path can read them
+        // as a plain slice.  Entries that normalize to nothing (empty values,
+        // a bare scheme) are dropped rather than rejected — a stray comma in
+        // the list is not worth refusing to start over.
+        self.cf_worker_domains = std::mem::take(&mut self.cf_worker_domains)
+            .iter()
+            .filter_map(|domain| Self::normalize_cf_worker_domain(domain))
+            .collect();
+
         // Fill in a random secret if none was supplied.
         if self.secrets.is_empty() {
             let bytes: [u8; 16] = rand::random();
@@ -576,18 +603,19 @@ impl Config {
             .find_map(|(id, ip)| (*id == dc).then_some(ip.as_str()))
     }
 
-    /// Cloudflare Worker domains normalized for `Host` and TLS SNI use.
-    pub fn cf_worker_domains(&self) -> Vec<String> {
-        self.cf_worker_domains
-            .iter()
-            .filter_map(|domain| Self::normalize_cf_worker_domain(domain))
-            .collect()
+    /// Cloudflare Worker domains, normalized for `Host` and TLS SNI use.
+    ///
+    /// Normalization happens once in [`Self::with_defaults`] rather than here:
+    /// this is read on the routing path of every connection, and rebuilding the
+    /// list per call put an allocation per domain there.
+    pub fn cf_worker_domains(&self) -> &[String] {
+        &self.cf_worker_domains
     }
 
     /// First normalized Cloudflare Worker domain.
     /// Kept for compatibility with single-domain call sites.
-    pub fn cf_worker_domain(&self) -> Option<String> {
-        self.cf_worker_domains().into_iter().next()
+    pub fn cf_worker_domain(&self) -> Option<&str> {
+        self.cf_worker_domains.first().map(String::as_str)
     }
 
     /// Cloudflare Worker domain normalized for `Host` and TLS SNI use.

--- a/src/default_domains/http.rs
+++ b/src/default_domains/http.rs
@@ -37,7 +37,10 @@ async fn https_get_with_tls_config(
 ) -> Result<String, String> {
     let connector = TlsConnector::from(tls_config);
 
-    let tcp = outbound.connect(host, 443, FETCH_TIMEOUT).await?;
+    let tcp = outbound
+        .connect(host, 443, FETCH_TIMEOUT)
+        .await
+        .map_err(|e| e.reason)?;
     let _ = tcp.set_nodelay(true);
 
     let server_name =

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ async fn main() {
     let cf_worker_domains = config.cf_worker_domains();
     if !cf_worker_domains.is_empty() {
         info!("  Cloudflare Worker domain(s):");
-        for domain in &cf_worker_domains {
+        for domain in cf_worker_domains {
             info!("    {}", domain);
         }
     }
@@ -262,9 +262,12 @@ async fn main() {
         Duration::from_secs(config.pool_max_age),
         Arc::clone(&runtime),
     ));
+    // Shared for the rest of the process: every connection reads the same
+    // settings, so they are behind one `Arc` instead of a per-connection clone.
+    let config = Arc::new(config);
     {
         let pool_clone = pool.clone();
-        let config_clone = config.clone();
+        let config_clone = Arc::clone(&config);
         tokio::spawn(async move {
             pool_clone.warmup(&config_clone).await;
         });
@@ -288,7 +291,7 @@ async fn main() {
 
         match listener.accept().await {
             Ok((stream, peer_addr)) => {
-                let cfg = config.clone();
+                let cfg = Arc::clone(&config);
                 let pool = pool.clone();
                 let runtime = Arc::clone(&runtime);
                 tokio::spawn(async move {

--- a/src/outbound/connector.rs
+++ b/src/outbound/connector.rs
@@ -8,6 +8,43 @@ use tokio_socks::tcp::Socks5Stream;
 
 use super::config::{OutboundConfig, ProxyConfig, ProxyKind, authority, http_host, target_url};
 
+/// Why an outbound connect failed.
+///
+/// The distinction is load-bearing: a refusal or reset means the address
+/// answered, while a timeout means nothing did — the signature of a
+/// DPI-blocked address, which the routing ladder treats very differently from
+/// an address that merely said no.  Carried as a flag rather than parsed back
+/// out of the message, whose wording varies by platform and proxy kind.
+#[derive(Debug, Clone)]
+pub struct OutboundError {
+    pub reason: String,
+    pub timed_out: bool,
+}
+
+impl OutboundError {
+    fn failed(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            timed_out: false,
+        }
+    }
+
+    fn timed_out(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            timed_out: true,
+        }
+    }
+}
+
+impl std::fmt::Display for OutboundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.reason)
+    }
+}
+
+impl std::error::Error for OutboundError {}
+
 pub struct OutboundConnector {
     config: OutboundConfig,
 }
@@ -41,7 +78,7 @@ impl OutboundConnector {
         target_host: &str,
         target_port: u16,
         timeout: Duration,
-    ) -> Result<TcpStream, String> {
+    ) -> Result<TcpStream, OutboundError> {
         let Some(proxy) = &self.config.proxy else {
             return connect_direct(target_host, target_port, timeout).await;
         };
@@ -50,9 +87,15 @@ impl OutboundConnector {
             return connect_direct(target_host, target_port, timeout).await;
         }
 
-        tokio::time::timeout(timeout, connect_via_proxy(proxy, target_host, target_port))
+        match tokio::time::timeout(timeout, connect_via_proxy(proxy, target_host, target_port))
             .await
-            .map_err(|_| format!("proxy {} handshake timed out", proxy.summary()))?
+        {
+            Ok(result) => result.map_err(OutboundError::failed),
+            Err(_) => Err(OutboundError::timed_out(format!(
+                "proxy {} handshake timed out",
+                proxy.summary()
+            ))),
+        }
     }
 
     fn should_bypass(&self, target_host: &str, target_port: u16) -> bool {
@@ -63,10 +106,15 @@ impl OutboundConnector {
     }
 }
 
-async fn connect_direct(host: &str, port: u16, timeout: Duration) -> Result<TcpStream, String> {
-    tokio::time::timeout(timeout, connect_tcp(host, port))
-        .await
-        .map_err(|_| "TCP connect timed out".to_string())?
+async fn connect_direct(
+    host: &str,
+    port: u16,
+    timeout: Duration,
+) -> Result<TcpStream, OutboundError> {
+    match tokio::time::timeout(timeout, connect_tcp(host, port)).await {
+        Ok(result) => result.map_err(OutboundError::failed),
+        Err(_) => Err(OutboundError::timed_out("TCP connect timed out")),
+    }
 }
 
 async fn connect_via_proxy(

--- a/src/outbound/mod.rs
+++ b/src/outbound/mod.rs
@@ -8,4 +8,4 @@
 mod config;
 mod connector;
 
-pub use connector::OutboundConnector;
+pub use connector::{OutboundConnector, OutboundError};

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -161,12 +161,18 @@ impl WsPool {
     ///
     /// Returns `Some(ws)` on a pool hit, `None` if the bucket is empty or
     /// all entries were stale.  Schedules a background refill either way.
+    /// `allow_refill` is the caller's verdict on whether `target_ip` is worth
+    /// dialling in the background at all.  A pre-connect into an address that
+    /// is currently timing out costs a connect timeout per pooled slot and can
+    /// never succeed, so the routing layer — which owns that knowledge — gets
+    /// to veto it.
     pub async fn get(
         self: &Arc<Self>,
         dc: u32,
         is_media: bool,
         target_ip: String,
         skip_tls_verify: bool,
+        allow_refill: bool,
     ) -> Option<TgWsStream> {
         let now = Instant::now();
         let mut lock = self.idle.lock().await;
@@ -204,10 +210,12 @@ impl WsPool {
             );
 
             // Schedule a background task to refill the bucket.
-            let pool = Arc::clone(self);
-            tokio::spawn(async move {
-                pool.refill(dc, is_media, target_ip, skip_tls_verify).await;
-            });
+            if allow_refill {
+                let pool = Arc::clone(self);
+                tokio::spawn(async move {
+                    pool.refill(dc, is_media, target_ip, skip_tls_verify).await;
+                });
+            }
 
             return Some(entry.ws);
         }
@@ -215,10 +223,12 @@ impl WsPool {
         // Bucket is empty (or fully stale).
         drop(lock);
 
-        let pool = Arc::clone(self);
-        tokio::spawn(async move {
-            pool.refill(dc, is_media, target_ip, skip_tls_verify).await;
-        });
+        if allow_refill {
+            let pool = Arc::clone(self);
+            tokio::spawn(async move {
+                pool.refill(dc, is_media, target_ip, skip_tls_verify).await;
+            });
+        }
 
         None
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -6,8 +6,16 @@
 //!
 //! The pool is keyed by `(dc_id, is_media)`.  Background refill tasks run
 //! after each pool hit to keep the bucket at `pool_size` connections.
+//!
+//! The Cloudflare tiers are pooled in the same struct but held to a much
+//! tighter budget — see [`CF_POOL_MAX`].  They matter more than the direct pool
+//! does: a client that reaches Telegram through Cloudflare pays *two*
+//! handshakes (to the Cloudflare edge, then Cloudflare's own connection onward)
+//! before its first byte moves, and Telegram opens a fresh connection per media
+//! transfer, so on a blocked network that cost lands on every download.
 
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::time::{Duration, Instant};
@@ -20,13 +28,78 @@ use futures_util::{FutureExt, StreamExt};
 use crate::config::Config;
 use crate::outbound::OutboundConnector;
 use crate::runtime::Runtime;
-use crate::ws_client::{TgWsStream, connect_ws_for_dc_with_outbound, media_tag};
+use crate::ws_client::{
+    TgWsStream, connect_cf_record_with_outbound, connect_cf_worker_ws_for_dc_with_outbound,
+    connect_ws_for_dc_with_outbound, media_tag,
+};
+
+/// Idle Cloudflare connections kept per `(tier, dc, is_media)`.
+///
+/// One, regardless of `--pool-size`.  Each one holds a connection open on
+/// someone else's account — a Worker request against its free-plan daily quota,
+/// or a socket on whichever `--cf-domain` served it, which with
+/// `--default-domains` is a community-run zone.  The pool is there to cover the
+/// *next* connection, not a burst.  Upstream settled on the same number for its
+/// Worker pool in v1.9.1.
+const CF_POOL_MAX: usize = 1;
+
+/// Which Cloudflare tier a pooled connection belongs to.  Pooled separately
+/// because the two are not interchangeable at the far end: a Worker is a raw
+/// TCP tunnel, a `--cf-domain` fronts Telegram's own WebSocket endpoint.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum CfTier {
+    Worker,
+    Proxy,
+}
+
+impl CfTier {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Worker => "CF Worker",
+            Self::Proxy => "CF proxy",
+        }
+    }
+}
 
 struct PoolEntry {
     ws: TgWsStream,
     created: Instant,
 }
 
+/// A pooled Cloudflare connection, tagged with the domain it was opened
+/// through so a pool hit logs like a fresh connect.
+struct CfEntry {
+    ws: TgWsStream,
+    created: Instant,
+    domain: String,
+    /// Kept alongside the connection so taking it from the pool is enough to
+    /// describe its replacement.
+    dst: String,
+    skip_tls_verify: bool,
+    connect_timeout: Duration,
+}
+
+/// Everything a background Cloudflare refill needs to reopen one connection.
+pub struct CfTarget {
+    pub tier: CfTier,
+    pub dc: u32,
+    pub is_media: bool,
+    /// Telegram DC IP the Worker opens its TCP tunnel to.  Unused by
+    /// [`CfTier::Proxy`], which reaches the DC through Cloudflare's own routing.
+    pub dst: String,
+    /// The domain that just served a connection for this tier.
+    pub domain: String,
+    pub skip_tls_verify: bool,
+    pub connect_timeout: Duration,
+}
+
+impl CfTarget {
+    fn key(&self) -> CfKey {
+        (self.tier, self.dc, self.is_media)
+    }
+}
+
+type CfKey = (CfTier, u32, bool);
 type Bucket = Vec<PoolEntry>;
 type PoolMap = HashMap<(u32, bool), Bucket>;
 
@@ -37,6 +110,8 @@ pub struct WsPool {
     max_age: Duration,
     runtime: Arc<Runtime>,
     idle: Mutex<PoolMap>,
+    cf_idle: Mutex<HashMap<CfKey, Vec<CfEntry>>>,
+    cf_refilling: StdMutex<HashSet<CfKey>>,
     /// Tracks which (dc, is_media) buckets currently have a refill in flight.
     /// Prevents a stampede of concurrent refill tasks when many clients arrive
     /// simultaneously — each `pool.get()` call spawns a refill, and without
@@ -48,14 +123,14 @@ pub struct WsPool {
     refilling: StdMutex<HashSet<(u32, bool)>>,
 }
 
-/// RAII guard that removes a `(dc, is_media)` key from the `refilling` set
-/// when dropped, guaranteeing cleanup even on early returns or panics.
-struct RefillGuard<'a> {
-    set: &'a StdMutex<HashSet<(u32, bool)>>,
-    key: (u32, bool),
+/// RAII guard that removes a bucket key from a `refilling` set when dropped,
+/// guaranteeing cleanup even on early returns or panics.
+struct RefillGuard<'a, K: Eq + Hash> {
+    set: &'a StdMutex<HashSet<K>>,
+    key: K,
 }
 
-impl Drop for RefillGuard<'_> {
+impl<K: Eq + Hash> Drop for RefillGuard<'_, K> {
     fn drop(&mut self) {
         self.set.lock().unwrap().remove(&self.key);
     }
@@ -76,6 +151,8 @@ impl WsPool {
             max_age,
             runtime,
             idle: Mutex::new(HashMap::new()),
+            cf_idle: Mutex::new(HashMap::new()),
+            cf_refilling: StdMutex::new(HashSet::new()),
             refilling: StdMutex::new(HashSet::new()),
         }
     }
@@ -144,6 +221,65 @@ impl WsPool {
         });
 
         None
+    }
+
+    /// Take a pre-opened Cloudflare connection, if one is idle and fresh.
+    ///
+    /// Returns the connection and the domain it runs through.  Cheap on a
+    /// miss — the routing path reaches this before it knows which domain it
+    /// will end up using, so nothing is built until there is something to
+    /// re-open.
+    pub async fn cf_get(
+        self: &Arc<Self>,
+        tier: CfTier,
+        dc: u32,
+        is_media: bool,
+    ) -> Option<(TgWsStream, String)> {
+        let now = Instant::now();
+        let mut lock = self.cf_idle.lock().await;
+        let bucket = lock.get_mut(&(tier, dc, is_media))?;
+
+        while let Some(mut entry) = bucket.pop() {
+            if now.saturating_duration_since(entry.created) > self.max_age
+                || entry.ws.next().now_or_never().is_some()
+            {
+                debug!(
+                    "{} pool: discarding stale DC{}{} connection",
+                    tier.label(),
+                    dc,
+                    media_tag(is_media)
+                );
+                continue;
+            }
+
+            drop(lock);
+            self.cf_prefetch(CfTarget {
+                tier,
+                dc,
+                is_media,
+                dst: entry.dst,
+                domain: entry.domain.clone(),
+                skip_tls_verify: entry.skip_tls_verify,
+                connect_timeout: entry.connect_timeout,
+            });
+
+            return Some((entry.ws, entry.domain));
+        }
+
+        None
+    }
+
+    /// Start opening one spare Cloudflare connection in the background.
+    ///
+    /// Deliberately only called off a connection that just worked, so a dead
+    /// Worker (or a network that cannot reach Cloudflare at all) is not
+    /// dialled again behind the user's back on every client connection.
+    pub fn cf_prefetch(self: &Arc<Self>, target: CfTarget) {
+        let pool = Arc::clone(self);
+
+        tokio::spawn(async move {
+            pool.cf_refill(target).await;
+        });
     }
 
     /// Warm up the pool for all configured DCs on startup.
@@ -229,6 +365,83 @@ impl WsPool {
         }
     }
 
+    async fn cf_refill(&self, target: CfTarget) {
+        let key = target.key();
+        if !self.cf_refilling.lock().unwrap().insert(key) {
+            return; // another refill is already in progress for this key
+        }
+        let _guard = RefillGuard {
+            set: &self.cf_refilling,
+            key,
+        };
+
+        // `--pool-size 0` disables pooling outright, exactly as it does for
+        // the direct pool — which an empty bucket must not talk its way out of.
+        let budget = CF_POOL_MAX.min(self.pool_size);
+        if self.cf_idle.lock().await.get(&key).map_or(0, Vec::len) >= budget {
+            return;
+        }
+
+        let Some(ws) = self.cf_connect_one(&target).await else {
+            return;
+        };
+
+        let mut lock = self.cf_idle.lock().await;
+        let bucket = lock.entry(key).or_default();
+
+        // The bucket may have been filled while this connect was in flight;
+        // dropping the surplus here closes its FD immediately.
+        if bucket.len() < budget {
+            debug!(
+                "{} pool refilled DC{}{} via {}",
+                target.tier.label(),
+                target.dc,
+                media_tag(target.is_media),
+                target.domain
+            );
+            bucket.push(CfEntry {
+                ws,
+                created: Instant::now(),
+                domain: target.domain,
+                dst: target.dst,
+                skip_tls_verify: target.skip_tls_verify,
+                connect_timeout: target.connect_timeout,
+            });
+        }
+    }
+
+    /// Re-open one connection of `target`'s tier through the domain that last
+    /// served this DC.
+    ///
+    /// The proxy tier is dialled with a single domain rather than the whole
+    /// `--cf-domain` list; that still covers its `kwsN` *and* `kwsN-1` records,
+    /// exactly as the inline path does.
+    async fn cf_connect_one(&self, target: &CfTarget) -> Option<TgWsStream> {
+        match target.tier {
+            CfTier::Worker => {
+                connect_cf_worker_ws_for_dc_with_outbound(
+                    &target.domain,
+                    &target.dst,
+                    target.dc,
+                    target.is_media,
+                    target.skip_tls_verify,
+                    target.connect_timeout,
+                    self.runtime.outbound(),
+                )
+                .await
+            }
+            CfTier::Proxy => {
+                connect_cf_record_with_outbound(
+                    &target.domain,
+                    target.skip_tls_verify,
+                    target.connect_timeout,
+                    self.runtime.outbound(),
+                )
+                .await
+            }
+        }
+    }
+
     async fn connect_batch(
         &self,
         ip: &str,
@@ -261,9 +474,10 @@ impl WsPool {
                 fronting_domain,
             )
             .await
+            .ws
             {
-                (Some(ws), _, _) => results.push(ws),
-                (None, _, _) => {
+                Some(ws) => results.push(ws),
+                None => {
                     warn!(
                         "pool: failed to pre-connect DC{}{}",
                         dc,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -644,25 +644,36 @@ async fn select_upstream(route: &Route<'_>, target_ip: Option<String>) -> Option
         return Some(upstream);
     }
 
-    // ── An IP that just timed out is skipped entirely ────────────────────
+    // ── An IP that just timed out is stepped over ────────────────────────
     // A DPI-blocked DC IP does not come back within one connection's
     // lifetime, so re-probing it per connection only adds the connect
     // timeout to every single client — the delay that makes Telegram sit in
     // "Connecting..." forever.  Only worth skipping when there is somewhere
     // else to go; without a fallback the doomed attempt is still the only
     // path we have.
-    if IP_FAIL.active(target_ip.as_str()) && route.has_fallback() {
+    let ip_cooling = IP_FAIL.active(target_ip.as_str()) && route.has_fallback();
+    if ip_cooling {
         let reason = "IP in cooldown";
         info!(
             "[{}] DC{}{} {} → skipping direct WS to {}",
             route.label, route.dc, route.media, reason, target_ip
         );
 
-        return Some(
-            route
-                .fallback_chain(&target_ip, reason, false)
-                .await
-                .unwrap_or_else(|| route.tcp_last_resort(target_ip, reason)),
+        // Stepped over, not written off: if every fallback is also gone the
+        // address gets its chance back rather than leaving the client on the
+        // raw-TCP path for the rest of the cooldown.  That is what makes the
+        // cooldown self-healing — a direct connect is the only thing that
+        // clears it, so something has to keep asking.
+        if let Some(upstream) = route
+            .fallback_chain(&target_ip, reason, route.config.cf_priority)
+            .await
+        {
+            return Some(upstream);
+        }
+
+        info!(
+            "[{}] DC{}{} every fallback failed → re-probing {}",
+            route.label, route.dc, route.media, target_ip
         );
     }
 
@@ -674,6 +685,7 @@ async fn select_upstream(route: &Route<'_>, target_ip: Option<String>) -> Option
             route.is_media,
             target_ip.clone(),
             route.config.skip_tls_verify,
+            !IP_FAIL.active(target_ip.as_str()),
         )
         .await;
     if let Some(ws) = pooled {
@@ -697,6 +709,13 @@ async fn select_upstream(route: &Route<'_>, target_ip: Option<String>) -> Option
     // WS failed (and is now in cooldown) — walk the rest of the ladder.
     // `--cf-priority` already tried both CF tiers above, so skip them here.
     let reason = "WS failed";
+    if ip_cooling {
+        // The re-probe above was the last thing left to try: every other tier
+        // already failed on the way in, and nothing since then can have
+        // revived them.
+        return Some(route.tcp_last_resort(target_ip, reason));
+    }
+
     Some(
         route
             .fallback_chain(&target_ip, reason, route.config.cf_priority)
@@ -743,20 +762,42 @@ impl Route<'_> {
     /// Describe the connection the pool should re-open, off the one that just
     /// worked.
     ///
-    /// Only the domain that actually answered is carried over, not the whole
-    /// candidate list: the spare is opened through the same route rather than
-    /// re-walking the ladder in the background, and a domain that stops working
-    /// simply stops refilling — the inline path still tries every candidate.
+    /// Only one domain is carried over, not the whole candidate list: the
+    /// spare is opened through a known-good route rather than re-walking the
+    /// ladder in the background, and a domain that stops working simply stops
+    /// refilling — the inline path still tries every candidate.
+    ///
+    /// Which one depends on `--cf-balance`.  Off, it is the domain that just
+    /// answered, so the pool inherits the same preference order the inline
+    /// path has.  On, pinning the pool to one domain would quietly undo the
+    /// balancing — roughly every other connection is a pool hit — so the spare
+    /// is opened through the next domain in the rotation instead.
     ///
     /// `dst` is only meaningful for [`CfTier::Worker`] — the DC IP its tunnel
     /// opens onto.
-    fn cf_target(&self, tier: CfTier, dst: &str, domain: &str) -> CfTarget {
+    fn cf_target(
+        &self,
+        tier: CfTier,
+        dst: &str,
+        domain: &str,
+        rotation: &[String],
+        counter: &AtomicUsize,
+    ) -> CfTarget {
+        let domain = if self.config.cf_balance {
+            balanced(rotation, counter)
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| domain.to_string())
+        } else {
+            domain.to_string()
+        };
+
         CfTarget {
             tier,
             dc: self.dc,
             is_media: self.is_media,
             dst: dst.to_string(),
-            domain: domain.to_string(),
+            domain,
             skip_tls_verify: self.config.skip_tls_verify,
             connect_timeout: self.timeouts.cf_connect,
         }
@@ -775,6 +816,13 @@ impl Route<'_> {
         if worker_domains.is_empty() {
             return None;
         }
+
+        // `--dc-ip` says which address *this host* should dial; the Worker
+        // dials from Cloudflare's network, where that choice carries no
+        // weight and a stale override would just send the tunnel somewhere
+        // dead. Upstream tg-ws-proxy likewise always tunnels to the built-in
+        // DC address.
+        let dst = self.runtime.fallback_ip(self.dc).unwrap_or(dst);
 
         if let Some((ws, domain)) = self
             .pool
@@ -832,8 +880,13 @@ impl Route<'_> {
                     // opens a new one per media transfer, and each pays the
                     // handshake to Cloudflare *and* Cloudflare's own connect
                     // to the DC.
-                    self.pool
-                        .cf_prefetch(self.cf_target(CfTier::Worker, dst, worker_domain));
+                    self.pool.cf_prefetch(self.cf_target(
+                        CfTier::Worker,
+                        dst,
+                        worker_domain,
+                        worker_domains,
+                        &CF_WORKER_BALANCE_COUNTER,
+                    ));
 
                     return Some(ws);
                 }
@@ -908,8 +961,13 @@ impl Route<'_> {
                 self.label, self.dc, self.media, reason
             );
             if let Some(domain) = domain {
-                self.pool
-                    .cf_prefetch(self.cf_target(CfTier::Proxy, "", &domain));
+                self.pool.cf_prefetch(self.cf_target(
+                    CfTier::Proxy,
+                    "",
+                    &domain,
+                    &self.config.cf_domains,
+                    &CF_BALANCE_COUNTER,
+                ));
             }
         } else {
             warn!(
@@ -984,6 +1042,10 @@ impl Route<'_> {
             .then(|| self.runtime.fronting_domain())
             .flatten();
 
+        // A DC inside its own cooldown is probed on a much shorter clock, so
+        // a timeout there says far less about the address than a full-budget
+        // one does — see `cool_down_ip`.
+        let probing = WS_FAIL.active(&(self.dc, self.is_media));
         let attempt = self.connect_ws(target_ip, sticky_fronting).await;
 
         if let Some(domain) = sticky_fronting {
@@ -1026,7 +1088,7 @@ impl Route<'_> {
         // unreachable.  A redirect, a refusal, or a handshake that stalled all
         // came from a host that is very much there, and taking it out of the
         // rotation for an hour on that basis would be wrong.
-        if attempt.connect_timed_out {
+        if attempt.connect_timed_out && !probing {
             self.cool_down_ip(target_ip);
         }
 
@@ -1143,13 +1205,12 @@ impl Route<'_> {
 
     /// Back off from a target IP whose TCP connect timed out.
     ///
-    /// Skipped when this is the only path available — see the `has_fallback`
-    /// check in [`select_upstream`], which is where the cooldown is honored.
+    /// Recorded even with no fallback tier configured, where nothing will skip
+    /// the address: the pool reads the same cooldown to stop pre-connecting
+    /// into a hole, which is worth doing either way.  [`select_upstream`] is
+    /// where the skipping decision — the part that does need a fallback — is
+    /// made.
     fn cool_down_ip(&self, target_ip: &str) {
-        if !self.has_fallback() {
-            return;
-        }
-
         IP_FAIL.set(target_ip.to_string(), self.timeouts.ip_fail_cooldown);
         info!(
             "[{}] DC{}{} TCP to {} timed out, cooldown {}s",

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -48,12 +48,12 @@ use crate::faketls::{
     read_tls_appdata, read_tls_record, sign_faketls_client_hello, write_tls_appdata,
 };
 use crate::outbound::OutboundConnector;
-use crate::pool::WsPool;
+use crate::pool::{CfTarget, CfTier, WsPool};
 use crate::runtime::Runtime;
 use crate::splitter::MsgSplitter;
 use crate::ws_client::{
-    TgWsStream, connect_cf_worker_ws_for_dc_with_outbound, connect_cf_ws_for_dc_with_outbound,
-    connect_ws_for_dc_with_outbound, media_tag, ws_send,
+    TgWsStream, WsAttempt, connect_cf_worker_ws_for_dc_with_outbound,
+    connect_cf_ws_for_dc_with_outbound, connect_ws_for_dc_with_outbound, media_tag, ws_send,
 };
 
 type TcpReader = ReadHalf<TcpStream>;
@@ -143,6 +143,14 @@ impl<K: Eq + Hash> CooldownMap<K> {
 /// Per-DC cooldown for the direct WebSocket path, keyed by `(dc, is_media)`.
 /// Also carries the longer "all domains redirected" cooldown.
 static WS_FAIL: CooldownMap<(u32, bool)> = CooldownMap::new();
+/// Per-target-IP cooldown, keyed by the `--dc-ip` address that timed out.
+///
+/// Coarser than `WS_FAIL` on purpose.  `WS_FAIL` says "this DC's WebSocket is
+/// unhappy, probe it with a short timeout"; this one says "TCP to this address
+/// does not complete at all", which is what a DPI-blocked IP looks like and
+/// does not change for hours.  Every DC sharing that address then skips the
+/// direct path outright instead of each paying a connect timeout.
+static IP_FAIL: CooldownMap<String> = CooldownMap::new();
 /// Per-upstream cooldown for MTProto proxies, keyed by `host:port`.
 static UPSTREAM_FAIL: CooldownMap<String> = CooldownMap::new();
 /// Per-Worker cooldown for the Cloudflare Worker path.
@@ -324,6 +332,7 @@ struct Timeouts {
     ws_fail_probe: Duration,
     ws_fail_cooldown: Duration,
     ws_redirect_cooldown: Duration,
+    ip_fail_cooldown: Duration,
     handshake: Duration,
     tcp_fallback: Duration,
     upstream_connect: Duration,
@@ -340,6 +349,7 @@ impl Timeouts {
             ws_fail_probe: Duration::from_secs(config.ws_fail_probe_timeout),
             ws_fail_cooldown: Duration::from_secs(config.ws_fail_cooldown),
             ws_redirect_cooldown: Duration::from_secs(config.ws_redirect_cooldown),
+            ip_fail_cooldown: Duration::from_secs(config.ip_fail_cooldown),
             handshake: Duration::from_secs(config.handshake_timeout),
             tcp_fallback: Duration::from_secs(config.tcp_fallback_timeout),
             upstream_connect: Duration::from_secs(config.upstream_connect_timeout),
@@ -352,10 +362,15 @@ impl Timeouts {
 }
 
 /// Handle one inbound client connection end-to-end.
+///
+/// `config` is shared rather than owned: it is read-only for the whole life of
+/// the process, and cloning it per connection meant copying every secret and
+/// domain list — with `--default-domains` that is a few dozen `String`s on the
+/// accept path.
 pub async fn handle_client(
     stream: TcpStream,
     peer: std::net::SocketAddr,
-    config: Config,
+    config: Arc<Config>,
     pool: Arc<WsPool>,
 ) {
     handle_client_with_runtime(
@@ -373,7 +388,7 @@ pub async fn handle_client(
 pub async fn handle_client_with_runtime(
     stream: TcpStream,
     peer: std::net::SocketAddr,
-    config: Config,
+    config: Arc<Config>,
     pool: Arc<WsPool>,
     runtime: Arc<Runtime>,
 ) {
@@ -465,6 +480,7 @@ pub async fn handle_client_with_runtime(
         label: &label,
         config: &config,
         runtime: &runtime,
+        pool: &pool,
         timeouts,
         dc: dc_id,
         is_media,
@@ -475,14 +491,15 @@ pub async fn handle_client_with_runtime(
     let target_ip = config.dc_target_ip(dc_id).map(str::to_string);
 
     // ── Step 6: bridge whatever we ended up connected to ─────────────────
-    match select_upstream(&route, &pool, target_ip).await {
-        Some(Upstream::Ws(ws)) => {
+    match select_upstream(&route, target_ip).await {
+        Some(Upstream::Ws { ws, framing }) => {
             bridge_ws(
                 reader,
                 writer,
                 WsBridgeParams {
                     label: &label,
                     ws,
+                    framing,
                     relay_init,
                     ciphers,
                     proto,
@@ -547,12 +564,35 @@ pub async fn handle_client_with_runtime(
 #[allow(clippy::large_enum_variant)]
 enum Upstream {
     /// A WebSocket to Telegram — direct, via the Cloudflare proxy, or through
-    /// a Cloudflare Worker tunnel.
-    Ws(TgWsStream),
+    /// a Cloudflare Worker tunnel.  See [`WsFraming`] for why the two are not
+    /// interchangeable once bridged.
+    Ws { ws: TgWsStream, framing: WsFraming },
     /// An upstream MTProto proxy, plain or FakeTLS-wrapped.
     Mtproto(UpstreamConnection),
     /// Last resort: a direct TCP connection to this Telegram DC IP.
     Tcp(String),
+}
+
+/// How the client's byte stream has to be cut into WebSocket messages.
+///
+/// The two upstream kinds want opposite things, and getting it wrong only
+/// shows up under load:
+///
+/// * Telegram's own `/apiws` endpoint (direct or fronted by the Cloudflare
+///   proxy) treats every WebSocket message as exactly one MTProto packet, so
+///   the stream must go through [`MsgSplitter`].
+/// * A Cloudflare Worker is a raw TCP tunnel — it writes each message's
+///   payload straight into the socket, so boundaries carry no meaning there.
+///   Packet-aligning for it is not just pointless but harmful: Cloudflare
+///   caps a WebSocket message at 1 MiB, and a media upload produces MTProto
+///   packets well past that, which killed the connection mid-transfer
+///   (Flowseal/tg-ws-proxy#1161, fixed upstream in v1.9.1).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum WsFraming {
+    /// One WebSocket message per MTProto packet.
+    Packets,
+    /// Opaque byte stream, chunked at whatever size reads off the client.
+    Tunnel,
 }
 
 /// Everything the fallback ladder needs to route one client connection.
@@ -560,6 +600,7 @@ struct Route<'a> {
     label: &'a str,
     config: &'a Config,
     runtime: &'a Runtime,
+    pool: &'a Arc<WsPool>,
     timeouts: Timeouts,
     dc: u32,
     is_media: bool,
@@ -575,11 +616,7 @@ struct Route<'a> {
 /// `target_ip` is the DC's `--dc-ip` override, if the user configured one.
 /// Without it the direct WebSocket path is skipped entirely and the Python
 /// reference's order is used (Worker, CF proxy, upstream proxies, then TCP).
-async fn select_upstream(
-    route: &Route<'_>,
-    pool: &Arc<WsPool>,
-    target_ip: Option<String>,
-) -> Option<Upstream> {
+async fn select_upstream(route: &Route<'_>, target_ip: Option<String>) -> Option<Upstream> {
     let Some(target_ip) = target_ip else {
         // Every log line already carries the DC, so the reason only has to say
         // what is missing.
@@ -600,15 +637,38 @@ async fn select_upstream(
         );
     };
 
-    // ── CF priority — try the CF proxy before direct WS if enabled ───────
+    // ── CF priority — try both CF tiers before direct WS if enabled ──────
     if route.config.cf_priority
-        && let Some(ws) = route.cf_proxy("cf-priority").await
+        && let Some(upstream) = route.cf_tiers(&target_ip, "cf-priority").await
     {
-        return Some(Upstream::Ws(ws));
+        return Some(upstream);
+    }
+
+    // ── An IP that just timed out is skipped entirely ────────────────────
+    // A DPI-blocked DC IP does not come back within one connection's
+    // lifetime, so re-probing it per connection only adds the connect
+    // timeout to every single client — the delay that makes Telegram sit in
+    // "Connecting..." forever.  Only worth skipping when there is somewhere
+    // else to go; without a fallback the doomed attempt is still the only
+    // path we have.
+    if IP_FAIL.active(target_ip.as_str()) && route.has_fallback() {
+        let reason = "IP in cooldown";
+        info!(
+            "[{}] DC{}{} {} → skipping direct WS to {}",
+            route.label, route.dc, route.media, reason, target_ip
+        );
+
+        return Some(
+            route
+                .fallback_chain(&target_ip, reason, false)
+                .await
+                .unwrap_or_else(|| route.tcp_last_resort(target_ip, reason)),
+        );
     }
 
     // ── Pool first, then a fresh WebSocket connect ───────────────────────
-    let pooled = pool
+    let pooled = route
+        .pool
         .get(
             route.dc,
             route.is_media,
@@ -621,28 +681,27 @@ async fn select_upstream(
             "[{}] DC{}{} → pool hit via {}",
             route.label, route.dc, route.media, target_ip
         );
-        return Some(Upstream::Ws(ws));
+        return Some(Upstream::Ws {
+            ws,
+            framing: WsFraming::Packets,
+        });
     }
 
     if let Some(ws) = route.direct_ws(&target_ip).await {
-        return Some(Upstream::Ws(ws));
+        return Some(Upstream::Ws {
+            ws,
+            framing: WsFraming::Packets,
+        });
     }
 
     // WS failed (and is now in cooldown) — walk the rest of the ladder.
-    // `--cf-priority` already tried the CF proxy above, so skip it here.
+    // `--cf-priority` already tried both CF tiers above, so skip them here.
     let reason = "WS failed";
     Some(
         route
             .fallback_chain(&target_ip, reason, route.config.cf_priority)
             .await
-            .unwrap_or_else(|| {
-                let fallback = route
-                    .runtime
-                    .fallback_ip(route.dc)
-                    .map_or(target_ip, str::to_string);
-
-                route.tcp_fallback(fallback, reason)
-            }),
+            .unwrap_or_else(|| route.tcp_last_resort(target_ip, reason)),
     )
 }
 
@@ -652,28 +711,86 @@ impl Route<'_> {
     ///
     /// `dst` is the Telegram DC IP the Worker should open its TCP tunnel to.
     /// Returns `None` when every configured tier failed or was skipped.
-    async fn fallback_chain(
-        &self,
-        dst: &str,
-        reason: &str,
-        skip_cf_proxy: bool,
-    ) -> Option<Upstream> {
-        if let Some(ws) = self.cf_worker(dst, reason).await {
-            return Some(Upstream::Ws(ws));
-        }
-
-        if !skip_cf_proxy && let Some(ws) = self.cf_proxy(reason).await {
-            return Some(Upstream::Ws(ws));
+    async fn fallback_chain(&self, dst: &str, reason: &str, skip_cf: bool) -> Option<Upstream> {
+        if !skip_cf && let Some(upstream) = self.cf_tiers(dst, reason).await {
+            return Some(upstream);
         }
 
         self.upstream_proxies(reason).await.map(Upstream::Mtproto)
     }
 
+    /// Both Cloudflare tiers in upstream's order: Worker tunnel first, then
+    /// the Cloudflare proxy.
+    ///
+    /// Kept as one step so `--cf-priority` and the post-failure fallback walk
+    /// the identical ladder — a Worker-only setup used to sit out
+    /// `--cf-priority` entirely and pay the full direct-WS timeout on every
+    /// connection before reaching its only working path.
+    async fn cf_tiers(&self, dst: &str, reason: &str) -> Option<Upstream> {
+        if let Some(ws) = self.cf_worker(dst, reason).await {
+            return Some(Upstream::Ws {
+                ws,
+                framing: WsFraming::Tunnel,
+            });
+        }
+
+        self.cf_proxy(reason).await.map(|ws| Upstream::Ws {
+            ws,
+            framing: WsFraming::Packets,
+        })
+    }
+
+    /// Describe the connection the pool should re-open, off the one that just
+    /// worked.
+    ///
+    /// Only the domain that actually answered is carried over, not the whole
+    /// candidate list: the spare is opened through the same route rather than
+    /// re-walking the ladder in the background, and a domain that stops working
+    /// simply stops refilling — the inline path still tries every candidate.
+    ///
+    /// `dst` is only meaningful for [`CfTier::Worker`] — the DC IP its tunnel
+    /// opens onto.
+    fn cf_target(&self, tier: CfTier, dst: &str, domain: &str) -> CfTarget {
+        CfTarget {
+            tier,
+            dc: self.dc,
+            is_media: self.is_media,
+            dst: dst.to_string(),
+            domain: domain.to_string(),
+            skip_tls_verify: self.config.skip_tls_verify,
+            connect_timeout: self.timeouts.cf_connect,
+        }
+    }
+
+    /// Whether anything other than the direct WebSocket path is configured.
+    fn has_fallback(&self) -> bool {
+        !self.config.cf_worker_domains().is_empty()
+            || !self.config.cf_domains.is_empty()
+            || !self.config.mtproto_proxies.is_empty()
+    }
+
     /// Try every configured Cloudflare Worker tunnel in `--cf-balance` order.
     async fn cf_worker(&self, dst: &str, reason: &str) -> Option<TgWsStream> {
         let worker_domains = self.config.cf_worker_domains();
+        if worker_domains.is_empty() {
+            return None;
+        }
+
+        if let Some((ws, domain)) = self
+            .pool
+            .cf_get(CfTier::Worker, self.dc, self.is_media)
+            .await
+        {
+            info!(
+                "[{}] DC{}{} {} → CF Worker pool hit ({})",
+                self.label, self.dc, self.media, reason, domain
+            );
+
+            return Some(ws);
+        }
+
         let workers = balance_order(
-            &worker_domains,
+            worker_domains,
             self.config.cf_balance,
             &CF_WORKER_BALANCE_COUNTER,
         );
@@ -710,6 +827,14 @@ impl Route<'_> {
                         "[{}] DC{}{} {} → CF Worker connected ({})",
                         self.label, self.dc, self.media, reason, worker_domain
                     );
+                    // This Worker answers, so it is worth holding a spare
+                    // tunnel open for the client's next connection — Telegram
+                    // opens a new one per media transfer, and each pays the
+                    // handshake to Cloudflare *and* Cloudflare's own connect
+                    // to the DC.
+                    self.pool
+                        .cf_prefetch(self.cf_target(CfTier::Worker, dst, worker_domain));
+
                     return Some(ws);
                 }
                 None => {
@@ -748,12 +873,26 @@ impl Route<'_> {
             self.config.cf_balance,
             &CF_BALANCE_COUNTER,
         );
+
+        if let Some((ws, domain)) = self
+            .pool
+            .cf_get(CfTier::Proxy, self.dc, self.is_media)
+            .await
+        {
+            info!(
+                "[{}] DC{}{} {} → CF proxy pool hit ({})",
+                self.label, self.dc, self.media, reason, domain
+            );
+
+            return Some(ws);
+        }
+
         debug!(
             "[{}] DC{}{} {} → trying CF proxy via {:?}",
             self.label, self.dc, self.media, reason, cf_domains
         );
 
-        let (ws, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
+        let (ws, domain, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
             self.dc,
             &cf_domains,
             self.is_media,
@@ -768,6 +907,10 @@ impl Route<'_> {
                 "[{}] DC{}{} {} → CF proxy connected",
                 self.label, self.dc, self.media, reason
             );
+            if let Some(domain) = domain {
+                self.pool
+                    .cf_prefetch(self.cf_target(CfTier::Proxy, "", &domain));
+            }
         } else {
             warn!(
                 "[{}] DC{}{} CF proxy failed (all configured domains)",
@@ -841,12 +984,12 @@ impl Route<'_> {
             .then(|| self.runtime.fronting_domain())
             .flatten();
 
-        let (ws, all_redirects, timed_out) = self.connect_ws(target_ip, sticky_fronting).await;
+        let attempt = self.connect_ws(target_ip, sticky_fronting).await;
 
         if let Some(domain) = sticky_fronting {
-            if ws.is_some() {
+            if attempt.ws.is_some() {
                 self.on_fronting_success(domain);
-                return ws;
+                return attempt.ws;
             }
 
             self.runtime.deactivate_fronting();
@@ -861,33 +1004,50 @@ impl Route<'_> {
                 self.media,
                 self.timeouts.fronting_fail_cooldown.as_secs()
             );
-        } else if ws.is_some() {
+        } else if attempt.ws.is_some() {
             WS_FAIL.clear(&(self.dc, self.is_media));
+            IP_FAIL.clear(target_ip);
             info!(
                 "[{}] DC{}{} → WS connected via {}",
                 self.label, self.dc, self.media, target_ip
             );
 
-            return ws;
-        } else if let Some(ws) = self.reactive_fronting(target_ip, timed_out).await {
+            return attempt.ws;
+        } else if let Some(ws) = self
+            .reactive_fronting(target_ip, attempt.upgrade_timed_out)
+            .await
+        {
             return Some(ws);
         }
 
-        self.cool_down_ws(all_redirects);
+        self.cool_down_ws(attempt.all_redirects);
+
+        // Only a TCP connect that ran out the clock says the address itself is
+        // unreachable.  A redirect, a refusal, or a handshake that stalled all
+        // came from a host that is very much there, and taking it out of the
+        // rotation for an hour on that basis would be wrong.
+        if attempt.connect_timed_out {
+            self.cool_down_ip(target_ip);
+        }
 
         None
     }
 
-    /// Retry a timed-out WebSocket connect once with a fronted SNI.
+    /// Retry a stalled WebSocket *handshake* once with a fronted SNI.
     ///
-    /// A timeout (as opposed to a redirect or connection error) is the signal
-    /// for SNI-based DPI blocking, which is exactly what fronting works
-    /// around.  Skipped while a previous fronting attempt is in its own
-    /// fail-cooldown: a network that blocks the DC IP outright would otherwise
-    /// pay for this doomed attempt on every single connection (see
-    /// `Config::fronting_fail_cooldown`).
-    async fn reactive_fronting(&self, target_ip: &str, timed_out: bool) -> Option<TgWsStream> {
-        if !timed_out || FRONTING_FAIL.active(&(self.dc, self.is_media)) {
+    /// Gated on the TLS/upgrade timeout specifically: that is the address
+    /// answering and then the handshake going nowhere, which is what SNI-based
+    /// DPI looks like and what fronting works around.  A TCP connect that never
+    /// completed is a different problem — nothing is listening as far as this
+    /// host can tell, and a different SNI on a connection that cannot be opened
+    /// changes nothing.  Also skipped while a previous fronting attempt is in
+    /// its own fail-cooldown (see `Config::fronting_fail_cooldown`).
+    async fn reactive_fronting(
+        &self,
+        target_ip: &str,
+        upgrade_timed_out: bool,
+    ) -> Option<TgWsStream> {
+        if !upgrade_timed_out || FRONTING_FAIL.active(&(self.dc, self.is_media)) {
             return None;
         }
         let domain = self.runtime.fronting_domain()?;
@@ -897,9 +1057,7 @@ impl Route<'_> {
             self.label, self.dc, self.media, domain
         );
 
-        let (ws, _all_redirects, _timed_out) = self.connect_ws(target_ip, Some(domain)).await;
-
-        match ws {
+        match self.connect_ws(target_ip, Some(domain)).await.ws {
             Some(ws) => {
                 self.on_fronting_success(domain);
                 Some(ws)
@@ -921,11 +1079,7 @@ impl Route<'_> {
         }
     }
 
-    async fn connect_ws(
-        &self,
-        target_ip: &str,
-        sni_override: Option<&str>,
-    ) -> (Option<TgWsStream>, bool, bool) {
+    async fn connect_ws(&self, target_ip: &str, sni_override: Option<&str>) -> WsAttempt {
         // A DC still inside its failure cooldown is probed with a much shorter
         // timeout so a doomed attempt does not delay the fallback chain.
         let timeout = if WS_FAIL.active(&(self.dc, self.is_media)) {
@@ -987,6 +1141,41 @@ impl Route<'_> {
         }
     }
 
+    /// Back off from a target IP whose TCP connect timed out.
+    ///
+    /// Skipped when this is the only path available — see the `has_fallback`
+    /// check in [`select_upstream`], which is where the cooldown is honored.
+    fn cool_down_ip(&self, target_ip: &str) {
+        if !self.has_fallback() {
+            return;
+        }
+
+        IP_FAIL.set(target_ip.to_string(), self.timeouts.ip_fail_cooldown);
+        info!(
+            "[{}] DC{}{} TCP to {} timed out, cooldown {}s",
+            self.label,
+            self.dc,
+            self.media,
+            target_ip,
+            self.timeouts.ip_fail_cooldown.as_secs()
+        );
+    }
+
+    /// Raw TCP to the DC, once every tunnelled tier is out.
+    ///
+    /// Prefers the built-in DC address over the `--dc-ip` override: this is
+    /// only reached after that override failed, and on the paths that get here
+    /// it failed by timing out — the one signal that says the address itself
+    /// is unreachable.
+    fn tcp_last_resort(&self, target_ip: String, reason: &str) -> Upstream {
+        let dst = self
+            .runtime
+            .fallback_ip(self.dc)
+            .map_or(target_ip, str::to_string);
+
+        self.tcp_fallback(dst, reason)
+    }
+
     fn tcp_fallback(&self, dst: String, reason: &str) -> Upstream {
         info!(
             "[{}] DC{}{} {} → TCP fallback {}:443",
@@ -1009,6 +1198,7 @@ impl Route<'_> {
 struct WsBridgeParams<'a> {
     label: &'a str,
     ws: TgWsStream,
+    framing: WsFraming,
     relay_init: [u8; 64],
     ciphers: ConnectionCiphers,
     proto: ProtoTag,
@@ -1020,6 +1210,7 @@ async fn bridge_ws(reader: ClientReader, writer: ClientWriter, params: WsBridgeP
     let WsBridgeParams {
         label,
         mut ws,
+        framing,
         relay_init,
         ciphers,
         proto,
@@ -1039,7 +1230,8 @@ async fn bridge_ws(reader: ClientReader, writer: ClientWriter, params: WsBridgeP
         mut tg_enc,
         mut tg_dec,
     } = ciphers;
-    let mut splitter = MsgSplitter::new(&relay_init, proto);
+    let mut splitter =
+        (framing == WsFraming::Packets).then(|| MsgSplitter::new(&relay_init, proto));
 
     // Split the WebSocket stream into sink (send) and source (recv).
     let (mut ws_sink, mut ws_source) = ws.split();
@@ -1065,18 +1257,38 @@ async fn bridge_ws(reader: ClientReader, writer: ClientWriter, params: WsBridgeP
                 clt_dec.apply_keystream(chunk);
                 tg_enc.apply_keystream(chunk);
 
-                // Split into MTProto packets and send as separate WS frames.
-                for part in splitter.split(chunk) {
-                    if ws_sink.send(Message::Binary(part)).await.is_err() {
-                        return;
+                let sent = match splitter.as_mut() {
+                    // Split into MTProto packets and send as separate WS frames.
+                    Some(splitter) => {
+                        let mut sent = true;
+                        for part in splitter.split(chunk) {
+                            if ws_sink.send(Message::Binary(part)).await.is_err() {
+                                sent = false;
+                                break;
+                            }
+                        }
+                        sent
                     }
+                    // Tunnel: forward the read as one frame.  A client read is
+                    // bounded by `CLIENT_READ_BUF_SIZE`, far under Cloudflare's
+                    // 1 MiB message cap, so it needs no further chunking — and
+                    // no intermediate `Vec` of parts either.
+                    None => ws_sink.send(Message::Binary(chunk.to_vec())).await.is_ok(),
+                };
+
+                if !sent {
+                    return;
                 }
 
                 counters.add_up(n);
             }
 
             // Flush any partial last packet.
-            for part in splitter.flush() {
+            for part in splitter
+                .as_mut()
+                .map(MsgSplitter::flush)
+                .unwrap_or_default()
+            {
                 let _ = ws_sink.send(Message::Binary(part)).await;
             }
 

--- a/src/proxy/tests.rs
+++ b/src/proxy/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::crypto::HANDSHAKE_LEN;
+
 #[test]
 fn balanced_rotates_the_starting_domain() {
     let counter = AtomicUsize::new(0);
@@ -164,4 +166,99 @@ fn bridge_counters_accumulate_across_many_chunks() {
     }
 
     assert_eq!(counters.totals(), (1000, 2500));
+}
+
+// ─── WebSocket framing ───────────────────────────────────────────────────────
+
+/// Bridge one client payload through `bridge_ws` and report the size of every
+/// WebSocket message the upstream received.
+///
+/// Both ends are plain TCP: the framing decision under test happens above the
+/// transport, so wrapping the stream in `MaybeTlsStream::Plain` exercises the
+/// same code a real TLS connection would.
+async fn upstream_frame_sizes(framing: WsFraming, payload: &[u8]) -> Vec<usize> {
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{MaybeTlsStream, accept_async, client_async};
+
+    let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = upstream.local_addr().unwrap();
+    let sizes = tokio::spawn(async move {
+        let (stream, _) = upstream.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        let mut sizes = Vec::new();
+
+        while let Some(Ok(message)) = ws.next().await {
+            match message {
+                Message::Binary(data) => sizes.push(data.len()),
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+
+        sizes
+    });
+
+    let tcp = TcpStream::connect(upstream_addr).await.unwrap();
+    let (ws, _) = client_async("ws://127.0.0.1/apiws", MaybeTlsStream::Plain(tcp))
+        .await
+        .unwrap();
+
+    // The client half of the bridge, driven from this test.
+    let clients = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let clients_addr = clients.local_addr().unwrap();
+    let mut client = TcpStream::connect(clients_addr).await.unwrap();
+    let (server, _) = clients.accept().await.unwrap();
+    let (reader, writer) = tokio::io::split(server);
+
+    let relay_init = generate_relay_init(ProtoTag::PaddedIntermediate, 2);
+    let ciphers = build_connection_ciphers(&[0u8; 48], &[0u8; 32], &relay_init);
+
+    let bridge = tokio::spawn(async move {
+        bridge_ws(
+            ClientReader::Plain(reader),
+            ClientWriter::Plain(writer),
+            WsBridgeParams {
+                label: "test",
+                ws,
+                framing,
+                relay_init,
+                ciphers,
+                proto: ProtoTag::PaddedIntermediate,
+                dc: 2,
+                is_media: false,
+            },
+        )
+        .await;
+    });
+
+    client.write_all(payload).await.unwrap();
+    drop(client);
+    bridge.await.unwrap();
+
+    sizes.await.unwrap()
+}
+
+#[tokio::test]
+async fn a_worker_tunnel_never_emits_an_oversized_frame() {
+    // Regression for the upload bug upstream fixed in v1.9.1: packet-aligning
+    // a Worker tunnel produces one WebSocket message per MTProto packet, and a
+    // media upload's packets run past Cloudflare's 1 MiB message cap, which
+    // kills the connection mid-transfer. A tunnel is a raw TCP socket at the
+    // far end, so it is chunked by client reads instead — and the relay init
+    // still goes out as its own first frame.
+    const CF_MESSAGE_CAP: usize = 1024 * 1024;
+    let payload = vec![0xA5; 3 * CF_MESSAGE_CAP];
+
+    let sizes = upstream_frame_sizes(WsFraming::Tunnel, &payload).await;
+
+    assert_eq!(sizes.first(), Some(&HANDSHAKE_LEN));
+    assert!(
+        sizes[1..].iter().all(|size| *size <= CLIENT_READ_BUF_SIZE),
+        "a tunnel frame must not exceed one client read: {sizes:?}"
+    );
+    assert_eq!(
+        sizes[1..].iter().sum::<usize>(),
+        payload.len(),
+        "every byte the client sent has to reach the upstream: {sizes:?}"
+    );
 }

--- a/src/ws_client.rs
+++ b/src/ws_client.rs
@@ -92,10 +92,47 @@ pub enum WsConnectResult {
     Redirect(u16),
     /// Any other non-101 status code or transport error.
     Failed(String),
-    /// The connection attempt did not complete within the given timeout.
-    /// Kept distinct from `Failed` so callers can trigger timeout-specific
-    /// fallbacks (e.g. domain fronting) without string-matching error text.
+    /// The TCP connect ran out the clock: nothing at `ip:443` answered.
+    ///
+    /// Distinct from [`Self::TimedOut`] because the two call for opposite
+    /// responses. Nothing answered here, so the address is treated as blocked
+    /// and skipped — swapping the SNI cannot conjure up a route to it.
+    ConnectTimedOut(String),
+    /// The TLS handshake or WebSocket upgrade ran out the clock.
+    ///
+    /// The address *did* answer and then the handshake stalled, which is what
+    /// SNI-based DPI looks like — so this is the one that triggers domain
+    /// fronting.
     TimedOut,
+}
+
+/// The outcome of walking one DC's WebSocket hostnames.
+///
+/// The three flags are what the routing ladder backs off on, and they are
+/// deliberately not collapsed into one "it failed" bit: each points at a
+/// different fallback (fronting, skipping the address, plain TCP).
+pub struct WsAttempt {
+    pub ws: Option<TgWsStream>,
+    /// Every hostname answered with a redirect — Telegram has taken the
+    /// WebSocket path away for this DC rather than the network blocking it.
+    pub all_redirects: bool,
+    /// A TLS/upgrade handshake stalled: the address answers, the handshake
+    /// does not finish.  The SNI-blocking signature that domain fronting is
+    /// for.
+    pub upgrade_timed_out: bool,
+    /// A TCP connect stalled: nothing at the address answered at all.
+    pub connect_timed_out: bool,
+}
+
+impl WsAttempt {
+    fn connected(ws: TgWsStream) -> Self {
+        Self {
+            ws: Some(ws),
+            all_redirects: false,
+            upgrade_timed_out: false,
+            connect_timed_out: false,
+        }
+    }
 }
 
 /// Try to establish a WebSocket connection to one Telegram DC domain.
@@ -170,9 +207,8 @@ async fn connect_ws_with_path(
     // ── TCP connection to the configured IP ──────────────────────────────
     let tcp = match outbound.connect(ip, 443, timeout).await {
         Ok(s) => s,
-        Err(e) => {
-            return WsConnectResult::Failed(e);
-        }
+        Err(e) if e.timed_out => return WsConnectResult::ConnectTimedOut(e.reason),
+        Err(e) => return WsConnectResult::Failed(e.reason),
     };
 
     // Disable Nagle algorithm for lower latency.
@@ -320,7 +356,7 @@ pub async fn connect_ws_for_dc(
     skip_tls_verify: bool,
     timeout: Duration,
 ) -> (Option<TgWsStream>, bool) {
-    let (ws, all_redirects, _timed_out) = connect_ws_for_dc_with_outbound(
+    let attempt = connect_ws_for_dc_with_outbound(
         ip,
         dc,
         is_media,
@@ -330,16 +366,17 @@ pub async fn connect_ws_for_dc(
         None,
     )
     .await;
-    (ws, all_redirects)
+
+    (attempt.ws, attempt.all_redirects)
 }
 
 /// Same as [`connect_ws_for_dc`], but routes each TCP connection through the
 /// supplied outbound connector.
 ///
 /// `sni_override` is forwarded to every domain attempt — see
-/// [`connect_ws_with_path`] for what it does. Returns
-/// `(stream, all_redirects, any_timed_out)`, where `any_timed_out` is `true`
-/// when at least one domain attempt hit the connect timeout (as opposed to a
+/// [`connect_ws_with_path`] for what it does. Returns a [`WsAttempt`] whose
+/// flags say *how* the attempt failed, which is what the caller's next step
+/// hangs on (as opposed to a
 /// redirect or other failure) — used to trigger the domain-fronting fallback.
 pub async fn connect_ws_for_dc_with_outbound(
     ip: &str,
@@ -349,11 +386,12 @@ pub async fn connect_ws_for_dc_with_outbound(
     timeout: Duration,
     outbound: &OutboundConnector,
     sni_override: Option<&str>,
-) -> (Option<TgWsStream>, bool, bool) {
+) -> WsAttempt {
     let domains = ws_domains(dc, is_media);
     let media = media_tag(is_media);
     let mut all_redirects = true;
-    let mut any_timed_out = false;
+    let mut any_upgrade_timed_out = false;
+    let mut any_connect_timed_out = false;
 
     for domain in &domains {
         debug!("WS trying DC{}{} → {} via {}", dc, media, domain, ip);
@@ -362,7 +400,7 @@ pub async fn connect_ws_for_dc_with_outbound(
             .await
         {
             WsConnectResult::Connected(ws) => {
-                return (Some(ws), false, false);
+                return WsAttempt::connected(ws);
             }
             WsConnectResult::Redirect(code) => {
                 warn!(
@@ -380,12 +418,23 @@ pub async fn connect_ws_for_dc_with_outbound(
                 warn!("WS DC{}{} timed out on {}", dc, media, domain);
 
                 all_redirects = false;
-                any_timed_out = true;
+                any_upgrade_timed_out = true;
+            }
+            WsConnectResult::ConnectTimedOut(reason) => {
+                warn!("WS DC{}{} failed on {}: {}", dc, media, domain, reason);
+
+                all_redirects = false;
+                any_connect_timed_out = true;
             }
         }
     }
 
-    (None, all_redirects, any_timed_out)
+    WsAttempt {
+        ws: None,
+        all_redirects,
+        upgrade_timed_out: any_upgrade_timed_out,
+        connect_timed_out: any_connect_timed_out,
+    }
 }
 
 /// WebSocket domains for a given DC when routing through one or more
@@ -526,15 +575,17 @@ impl CfAttempts {
 /// proxy transparently retries the same DC using `kws{N}` — the user only needs
 /// to configure the base record in Cloudflare.
 ///
-/// Returns `(Some(stream), all_redirects)` with the same semantics as
-/// [`connect_ws_for_dc`].
+/// Returns `(Some(stream), record, all_redirects)`, where `record` is the
+/// expanded `kws{N}` hostname that answered — the caller can reconnect straight
+/// to it with [`connect_cf_record_with_outbound`] instead of walking the list
+/// again.  `all_redirects` has the same semantics as [`connect_ws_for_dc`].
 pub async fn connect_cf_ws_for_dc(
     dc: u32,
     cf_domains: &[String],
     is_media: bool,
     skip_tls_verify: bool,
     timeout: Duration,
-) -> (Option<TgWsStream>, bool) {
+) -> (Option<TgWsStream>, Option<String>, bool) {
     connect_cf_ws_for_dc_with_outbound(
         dc,
         cf_domains,
@@ -555,7 +606,7 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
     skip_tls_verify: bool,
     timeout: Duration,
     outbound: &OutboundConnector,
-) -> (Option<TgWsStream>, bool) {
+) -> (Option<TgWsStream>, Option<String>, bool) {
     let media = media_tag(is_media);
     let mut all_redirects = true;
     let mut attempts = CfAttempts::new(cf_ws_domains(dc, cf_domains, is_media));
@@ -569,7 +620,7 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
             .await
         {
             WsConnectResult::Connected(ws) => {
-                return (Some(ws), false);
+                return (Some(ws), Some(domain), false);
             }
             WsConnectResult::Redirect(code) => {
                 warn!(
@@ -595,7 +646,7 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
                 warn!("CF WS DC{}{} failed on {}: {}", dc, media, domain, reason);
                 all_redirects = false;
             }
-            WsConnectResult::TimedOut => {
+            WsConnectResult::TimedOut | WsConnectResult::ConnectTimedOut(_) => {
                 warn!("CF WS DC{}{} timed out on {}", dc, media, domain);
                 attempts.note_timed_out(&domain);
                 all_redirects = false;
@@ -603,7 +654,24 @@ pub async fn connect_cf_ws_for_dc_with_outbound(
         }
     }
 
-    (None, all_redirects)
+    (None, None, all_redirects)
+}
+
+/// Reconnect to a single already-expanded `kws{N}` Cloudflare record.
+///
+/// Used by the pool to re-open the exact route that just served a client,
+/// skipping the per-DC record expansion and the `-1`/base fallback dance that
+/// [`connect_cf_ws_for_dc_with_outbound`] performs on a cold connect.
+pub async fn connect_cf_record_with_outbound(
+    record: &str,
+    skip_tls_verify: bool,
+    timeout: Duration,
+    outbound: &OutboundConnector,
+) -> Option<TgWsStream> {
+    match connect_ws_with_outbound(record, record, skip_tls_verify, timeout, outbound, None).await {
+        WsConnectResult::Connected(ws) => Some(ws),
+        _ => None,
+    }
 }
 
 /// Connect through a Cloudflare Worker TCP tunnel.
@@ -677,7 +745,7 @@ pub async fn connect_cf_worker_ws_for_dc_with_outbound(
             );
             None
         }
-        WsConnectResult::TimedOut => {
+        WsConnectResult::TimedOut | WsConnectResult::ConnectTimedOut(_) => {
             warn!("CF Worker DC{}{} timed out on {}", dc, media, worker_domain);
             None
         }

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -29,7 +29,8 @@ fn check_config(proxy_addr: &str, extra: &[&str]) -> Config {
     ];
     args.extend_from_slice(extra);
 
-    Config::try_parse_from(args).unwrap()
+    // Same normalization the binary applies before running a check.
+    Config::try_parse_from(args).unwrap().with_defaults()
 }
 
 #[tokio::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,6 +30,10 @@ pub const TASK_TIMEOUT: Duration = Duration::from_secs(5);
 /// connection before deciding the fallback chain is finished.
 const QUIET_PERIOD: Duration = Duration::from_millis(300);
 
+/// Same idea for [`stalling_http_proxy_requests`], but it has to outlast the
+/// connect timeout every stalled attempt burns before the next one arrives.
+const STALL_QUIET_PERIOD: Duration = Duration::from_millis(1500);
+
 /// Install the process-wide rustls crypto provider.
 ///
 /// Required by any test that performs a TLS handshake; safe to call from
@@ -78,6 +82,45 @@ pub async fn rejecting_http_proxy_requests() -> (SocketAddr, JoinHandle<Vec<Stri
             requests.push(read_http_connect_request(&mut inbound).await);
             reject(&mut inbound).await;
             budget = QUIET_PERIOD;
+        }
+
+        requests
+    });
+
+    (proxy_addr, proxy_task)
+}
+
+/// Like [`rejecting_http_proxy_requests`], but leaves every `CONNECT` whose
+/// target contains `stall_target` hanging with no answer at all, so the caller
+/// hits its connect *timeout* instead of a refusal.
+///
+/// The distinction matters to the routing code: a refusal says the address
+/// answered, a timeout says it is unreachable — only the latter is treated as
+/// a blocked IP.  Everything else is rejected immediately so the rest of the
+/// fallback chain still runs at full speed.
+pub async fn stalling_http_proxy_requests(
+    stall_target: &'static str,
+) -> (SocketAddr, JoinHandle<Vec<String>>) {
+    let proxy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = proxy.local_addr().unwrap();
+    let proxy_task = tokio::spawn(async move {
+        let mut requests = Vec::new();
+        // Held open (not dropped) for the whole run: closing a stalled socket
+        // would surface as a connection error rather than a timeout.
+        let mut stalled = Vec::new();
+        let mut budget = TASK_TIMEOUT;
+
+        while let Ok(Ok((mut inbound, _))) = tokio::time::timeout(budget, proxy.accept()).await {
+            let request = read_http_connect_request(&mut inbound).await;
+            if request.contains(stall_target) {
+                stalled.push(inbound);
+            } else {
+                reject(&mut inbound).await;
+            }
+            requests.push(request);
+            // Long enough to outlast the connect timeout a stalled attempt
+            // waits out before the next one starts.
+            budget = STALL_QUIET_PERIOD;
         }
 
         requests
@@ -247,7 +290,11 @@ pub async fn start_proxy_connection(config: Config) -> (TcpStream, JoinHandle<()
     let (server, peer) = accepted.unwrap();
 
     let handler = tokio::spawn(handle_client_with_runtime(
-        server, peer, config, pool, runtime,
+        server,
+        peer,
+        Arc::new(config),
+        pool,
+        runtime,
     ));
 
     (client.unwrap(), handler)

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -66,12 +66,10 @@ fn cf_worker_domain_accepts_python_alias_and_normalizes_url() {
         "--cfproxy-worker-domain",
         "https://example.user.workers.dev/apiws",
     ])
-    .unwrap();
+    .unwrap()
+    .with_defaults();
 
-    assert_eq!(
-        cfg.cf_worker_domain().as_deref(),
-        Some("example.user.workers.dev")
-    );
+    assert_eq!(cfg.cf_worker_domain(), Some("example.user.workers.dev"));
 }
 
 #[test]
@@ -81,7 +79,8 @@ fn cf_worker_domains_accept_multiple_values_and_normalize() {
         "--cf-worker-domain",
         "https://a.user.workers.dev/apiws,b.user.workers.dev/",
     ])
-    .unwrap();
+    .unwrap()
+    .with_defaults();
 
     assert_eq!(
         cfg.cf_worker_domains(),
@@ -180,14 +179,17 @@ fn cf_worker_domains_drop_empty_entries() {
         "--cf-worker-domain",
         "a.user.workers.dev,,  ,https://",
     ])
-    .unwrap();
+    .unwrap()
+    .with_defaults();
 
     assert_eq!(cfg.cf_worker_domains(), vec!["a.user.workers.dev"]);
 }
 
 #[test]
 fn cf_worker_domain_is_none_when_nothing_is_configured() {
-    let cfg = Config::try_parse_from(["tg-ws-proxy"]).unwrap();
+    let cfg = Config::try_parse_from(["tg-ws-proxy"])
+        .unwrap()
+        .with_defaults();
 
     assert_eq!(cfg.cf_worker_domain(), None);
     assert!(cfg.cf_worker_domains().is_empty());

--- a/tests/outbound.rs
+++ b/tests/outbound.rs
@@ -251,7 +251,7 @@ async fn http_connect_rejects_bad_status() {
         .await
         .unwrap_err();
 
-    assert!(err.contains("HTTP code is not equal 200: 407"));
+    assert!(err.reason.contains("HTTP code is not equal 200: 407"));
     await_task(proxy_task).await;
 }
 
@@ -410,7 +410,7 @@ async fn no_proxy_host_port_does_not_bypass_different_port() {
         .connect("example.local", 443, Duration::from_secs(2))
         .await
         .unwrap_err();
-    assert!(err.contains("407"));
+    assert!(err.reason.contains("407"));
     await_task(proxy_task).await;
 }
 
@@ -439,7 +439,7 @@ async fn explicit_empty_no_proxy_overrides_env_bypass() {
         .await
         .unwrap_err();
 
-    assert!(err.contains("407"));
+    assert!(err.reason.contains("407"));
     await_task(proxy_task).await;
 }
 
@@ -460,7 +460,7 @@ async fn proxy_handshake_uses_one_deadline() {
         .await
         .unwrap_err();
 
-    assert!(err.contains("handshake timed out"));
+    assert!(err.reason.contains("handshake timed out"));
     assert!(start.elapsed() < Duration::from_secs(1));
     proxy_task.abort();
     assert!(proxy_task.await.unwrap_err().is_cancelled());

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -5,12 +5,12 @@ use clap::Parser;
 
 use tg_ws_proxy_rs::config::Config;
 use tg_ws_proxy_rs::outbound::OutboundConnector;
-use tg_ws_proxy_rs::pool::WsPool;
+use tg_ws_proxy_rs::pool::{CfTarget, CfTier, WsPool};
 use tg_ws_proxy_rs::runtime::Runtime;
 
 mod common;
 
-use common::{await_proxy_requests, rejecting_http_proxy_requests};
+use common::{await_proxy_requests, rejecting_http_proxy, rejecting_http_proxy_requests};
 
 fn pool_with_outbound(pool_size: usize, outbound: OutboundConnector) -> Arc<WsPool> {
     Arc::new(WsPool::with_runtime(
@@ -93,5 +93,80 @@ async fn warmup_gives_up_on_unreachable_dcs_instead_of_hanging() {
         pool.get(2, false, "203.0.113.10".to_string(), false)
             .await
             .is_none()
+    );
+}
+
+// ─── Cloudflare tiers ────────────────────────────────────────────────────────
+
+fn worker_target(domain: &str) -> CfTarget {
+    CfTarget {
+        tier: CfTier::Worker,
+        dc: 2,
+        is_media: false,
+        dst: "149.154.167.51".to_string(),
+        domain: domain.to_string(),
+        skip_tls_verify: false,
+        connect_timeout: Duration::from_secs(2),
+    }
+}
+
+#[tokio::test]
+async fn a_cf_tier_that_was_never_primed_misses_without_dialling() {
+    // The routing path asks the pool before it knows which domain it will
+    // use, so a miss has to be free — no connect, nothing to build.
+    let (proxy_addr, proxy_task) = rejecting_http_proxy().await;
+    let outbound =
+        OutboundConnector::from_config(Some(&format!("http://{proxy_addr}")), None, false).unwrap();
+    let pool = pool_with_outbound(1, outbound);
+
+    assert!(pool.cf_get(CfTier::Worker, 2, false).await.is_none());
+    assert!(pool.cf_get(CfTier::Proxy, 2, false).await.is_none());
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), proxy_task)
+            .await
+            .is_err(),
+        "a pool miss must not dial anything"
+    );
+}
+
+#[tokio::test]
+async fn cf_prefetch_reopens_the_worker_through_the_outbound_connector() {
+    let (proxy_addr, proxy_task) = rejecting_http_proxy_requests().await;
+    let outbound =
+        OutboundConnector::from_config(Some(&format!("http://{proxy_addr}")), None, false).unwrap();
+    let pool = pool_with_outbound(1, outbound);
+
+    pool.cf_prefetch(worker_target("worker-prefetch.example.dev"));
+
+    let requests = await_proxy_requests(proxy_task).await;
+    assert_eq!(
+        requests.len(),
+        1,
+        "a prefetch opens exactly one spare tunnel: {requests:?}"
+    );
+    assert!(
+        requests[0].starts_with("CONNECT worker-prefetch.example.dev:443 HTTP/1.1"),
+        "unexpected prefetch target: {requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn cf_prefetch_does_nothing_when_pooling_is_disabled() {
+    // --pool-size 0 turns pooling off for the Cloudflare tiers too, rather
+    // than quietly keeping one connection per DC open on someone else's
+    // Worker quota.
+    let (proxy_addr, proxy_task) = rejecting_http_proxy().await;
+    let outbound =
+        OutboundConnector::from_config(Some(&format!("http://{proxy_addr}")), None, false).unwrap();
+    let pool = pool_with_outbound(0, outbound);
+
+    pool.cf_prefetch(worker_target("worker-disabled.example.dev"));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), proxy_task)
+            .await
+            .is_err(),
+        "pooling is disabled, so nothing should be dialled"
     );
 }

--- a/tests/pool.rs
+++ b/tests/pool.rs
@@ -24,7 +24,9 @@ fn pool_with_outbound(pool_size: usize, outbound: OutboundConnector) -> Arc<WsPo
 async fn an_empty_pool_misses_and_lets_the_caller_connect_directly() {
     let pool = pool_with_outbound(0, OutboundConnector::direct());
 
-    let hit = pool.get(2, false, "203.0.113.10".to_string(), false).await;
+    let hit = pool
+        .get(2, false, "203.0.113.10".to_string(), false, true)
+        .await;
 
     assert!(hit.is_none());
 }
@@ -39,7 +41,7 @@ async fn pool_refill_dials_through_the_outbound_connector() {
     let pool = pool_with_outbound(1, outbound);
 
     assert!(
-        pool.get(2, false, "203.0.113.10".to_string(), false)
+        pool.get(2, false, "203.0.113.10".to_string(), false, true)
             .await
             .is_none()
     );
@@ -90,7 +92,7 @@ async fn warmup_gives_up_on_unreachable_dcs_instead_of_hanging() {
 
     // Nothing was pooled, so a subsequent get still misses.
     assert!(
-        pool.get(2, false, "203.0.113.10".to_string(), false)
+        pool.get(2, false, "203.0.113.10".to_string(), false, true)
             .await
             .is_none()
     );

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -15,7 +15,8 @@ mod common;
 
 use common::{
     await_proxy_handler, await_proxy_request, await_proxy_requests, rejecting_http_proxy,
-    rejecting_http_proxy_requests, run_proxy_once, start_proxy_connection,
+    rejecting_http_proxy_requests, run_proxy_once, run_proxy_once_for_dc,
+    stalling_http_proxy_requests, start_proxy_connection,
 };
 
 const SECRET: &str = "00112233445566778899aabbccddeeff";
@@ -232,6 +233,93 @@ async fn cf_priority_tries_the_cf_proxy_before_the_direct_websocket() {
             // ...and finally the TCP fallback. CF is not tried a second time.
             "149.154.167.51:443",
         ]
+    );
+}
+
+#[tokio::test]
+async fn cf_priority_tries_the_cf_worker_before_the_direct_websocket() {
+    // Regression for #93: --cf-priority used to cover only --cf-domain, so a
+    // Worker-only setup still paid the full direct-WS timeout on every
+    // connection before reaching the one tier that worked.
+    let (proxy_addr, proxy_task) = rejecting_http_proxy_requests().await;
+    let config = proxy_config(
+        &format!("http://{proxy_addr}"),
+        &[
+            "--cf-priority",
+            "--cf-worker-domain",
+            "worker-priority.example.dev",
+            "--dc-ip",
+            "2:149.154.167.221",
+            "--ws-connect-timeout",
+            "2",
+        ],
+    );
+
+    run_proxy_once(config).await;
+
+    let requests = await_proxy_requests(proxy_task).await;
+    assert_eq!(
+        connect_targets(&requests),
+        [
+            // The Worker comes first...
+            "worker-priority.example.dev:443",
+            // ...then the direct WS attempt on both Telegram hostnames...
+            "149.154.167.221:443",
+            "149.154.167.221:443",
+            // ...and finally TCP. The Worker is not tried a second time.
+            "149.154.167.51:443",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_dc_ip_that_timed_out_is_skipped_on_the_next_connection() {
+    // A DPI-blocked DC IP costs a full connect timeout per attempt. Paying
+    // that on every connection is what leaves Telegram sitting in
+    // "Connecting..." — so once an address times out, later connections go
+    // straight to the tiers that can still reach Telegram.
+    const DEAD_IP: &str = "149.154.175.101";
+    let (proxy_addr, proxy_task) = stalling_http_proxy_requests(DEAD_IP).await;
+    let make_config = || {
+        proxy_config(
+            &format!("http://{proxy_addr}"),
+            &[
+                "--cf-worker-domain",
+                "worker-ipfail.example.dev",
+                "--dc-ip",
+                &format!("3:{DEAD_IP}"),
+                "--ws-connect-timeout",
+                "1",
+                "--ws-fail-probe-timeout",
+                "1",
+                "--cf-fail-cooldown",
+                "0",
+            ],
+        )
+    };
+
+    run_proxy_once_for_dc(make_config(), 3).await;
+    run_proxy_once_for_dc(make_config(), 3).await;
+
+    let requests = await_proxy_requests(proxy_task).await;
+    assert_eq!(
+        connect_targets(&requests),
+        [
+            // First connection probes the DC IP on both Telegram hostnames...
+            DEAD_IP,
+            DEAD_IP,
+            // ...then falls back to the Worker and finally to TCP.
+            "worker-ipfail.example.dev:443",
+            "149.154.175.100:443",
+            // The second one skips the dead address entirely.
+            "worker-ipfail.example.dev:443",
+            "149.154.175.100:443",
+        ]
+        .map(|target| if target == DEAD_IP {
+            format!("{DEAD_IP}:443")
+        } else {
+            target.to_string()
+        })
     );
 }
 

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -242,18 +242,21 @@ async fn cf_priority_tries_the_cf_worker_before_the_direct_websocket() {
     // Worker-only setup still paid the full direct-WS timeout on every
     // connection before reaching the one tier that worked.
     let (proxy_addr, proxy_task) = rejecting_http_proxy_requests().await;
+    // The domain is given in URL form on purpose: normalization happens once
+    // at startup now, so this is what keeps the routing path covered by it.
     let config = proxy_config(
         &format!("http://{proxy_addr}"),
         &[
             "--cf-priority",
             "--cf-worker-domain",
-            "worker-priority.example.dev",
+            "https://worker-priority.example.dev/apiws",
             "--dc-ip",
             "2:149.154.167.221",
             "--ws-connect-timeout",
             "2",
         ],
-    );
+    )
+    .with_defaults();
 
     run_proxy_once(config).await;
 
@@ -278,6 +281,11 @@ async fn a_dc_ip_that_timed_out_is_skipped_on_the_next_connection() {
     // that on every connection is what leaves Telegram sitting in
     // "Connecting..." — so once an address times out, later connections go
     // straight to the tiers that can still reach Telegram.
+    //
+    // Here every tier is dead, which is the case that must not turn into a
+    // one-hour lockout: with nothing else left the address is re-probed, so a
+    // cooldown set by a passing glitch can still be cleared by a connection
+    // that works.
     const DEAD_IP: &str = "149.154.175.101";
     let (proxy_addr, proxy_task) = stalling_http_proxy_requests(DEAD_IP).await;
     let make_config = || {
@@ -311,8 +319,12 @@ async fn a_dc_ip_that_timed_out_is_skipped_on_the_next_connection() {
             // ...then falls back to the Worker and finally to TCP.
             "worker-ipfail.example.dev:443",
             "149.154.175.100:443",
-            // The second one skips the dead address entirely.
+            // The second one goes to the Worker first, skipping the address...
             "worker-ipfail.example.dev:443",
+            // ...and only re-probes it because nothing else was left, on the
+            // short cooldown clock rather than the full connect timeout.
+            DEAD_IP,
+            DEAD_IP,
             "149.154.175.100:443",
         ]
         .map(|target| if target == DEAD_IP {

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -60,7 +60,7 @@ async fn old_handle_client_public_signature_still_compiles() {
     let _client = client.unwrap();
     let (server, peer) = accepted.unwrap();
 
-    let _future = handle_client(server, peer, config, pool);
+    let _future = handle_client(server, peer, std::sync::Arc::new(config), pool);
 }
 
 #[test]

--- a/tests/ws_client.rs
+++ b/tests/ws_client.rs
@@ -114,7 +114,7 @@ async fn telegram_ws_dc_connector_uses_outbound_proxy() {
     let outbound =
         OutboundConnector::from_config(Some(&format!("http://{proxy_addr}")), None, false).unwrap();
 
-    let (ws, all_redirects, timed_out) = connect_ws_for_dc_with_outbound(
+    let attempt = connect_ws_for_dc_with_outbound(
         "203.0.113.10",
         2,
         false,
@@ -125,11 +125,12 @@ async fn telegram_ws_dc_connector_uses_outbound_proxy() {
     )
     .await;
 
-    assert!(ws.is_none());
+    assert!(attempt.ws.is_none());
     // A rejected CONNECT is a hard failure, not a redirect and not a timeout —
     // the distinction drives which fallback the proxy reaches for next.
-    assert!(!all_redirects);
-    assert!(!timed_out);
+    assert!(!attempt.all_redirects);
+    assert!(!attempt.upgrade_timed_out);
+    assert!(!attempt.connect_timed_out);
     let request = await_proxy_request(proxy_task).await;
     assert!(request.starts_with("CONNECT 203.0.113.10:443 HTTP/1.1"));
 }
@@ -140,7 +141,7 @@ async fn cloudflare_ws_connector_uses_outbound_proxy() {
     let outbound =
         OutboundConnector::from_config(Some(&format!("http://{proxy_addr}")), None, false).unwrap();
 
-    let (ws, all_redirects) = connect_cf_ws_for_dc_with_outbound(
+    let (ws, _record, all_redirects) = connect_cf_ws_for_dc_with_outbound(
         2,
         &["example.net".to_string()],
         false,
@@ -164,7 +165,7 @@ async fn cloudflare_ws_connector_tries_every_record_of_every_domain() {
     let outbound =
         OutboundConnector::from_config(Some(&format!("http://{proxy_addr}")), None, false).unwrap();
 
-    let (ws, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
+    let (ws, _record, _all_redirects) = connect_cf_ws_for_dc_with_outbound(
         2,
         &["a.example".to_string(), "b.example".to_string()],
         false,


### PR DESCRIPTION
Closes #94. Also fixes the routing half of #93.

Приводит Cloudflare-пути к паритету с [Flowseal/tg-ws-proxy v1.9.1](https://github.com/Flowseal/tg-ws-proxy/releases/tag/v1.9.1) и чинит то, что из-за этого ломалось у пользователей.

## Баги

**1. Пакетная нарезка в туннель Cloudflare Worker.** Дальний конец воркера — сырой TCP-сокет, границы MTProto-пакетов там не значат ничего, а Cloudflare рубит WS-сообщения больше 1 MiB — ровно то, что пакеты медиа-аплоада и превышают. Апстрим починил это в v1.9.1 (`splitter=splitter` → `splitter=None`, коммит [`ecf3d6f3`](https://github.com/Flowseal/tg-ws-proxy/commit/ecf3d6f3), issues [#1161](https://github.com/Flowseal/tg-ws-proxy/issues/1161) / [#1155](https://github.com/Flowseal/tg-ws-proxy/issues/1155): «файлы больше 1 MB не заливаются при включённом CW, скачивание работает»). Для яруса `--cf-domain` сплиттер остаётся — там на том конце `/apiws` самого Telegram, которому нужна пакетная разбивка; апстрим поступает так же.

**2. `--cf-priority` не покрывал `--cf-worker-domain`.** Флаг дёргал только `cf_proxy()`, а тот выходит сразу, если `--cf-domain` пуст. Конфигурация «только воркер» полностью просиживала флаг и на каждое соединение выжидала полный таймаут прямого WS перед единственным работающим ярусом (#93).

**3. Адрес из `--dc-ip`, до которого TCP-коннект ушёл в таймаут, перепроверялся каждым соединением.** Теперь он перешагивается на `--ip-fail-cooldown` (по умолчанию час, как `IP_FAIL_COOLDOWN` у апстрима), если настроен хоть какой-то фолбэк. Перешагивается, а не списывается: если все фолбэки тоже легли, адрес перепроверяется, и первый удачный прямой коннект кулдаун снимает — окно, открытое случайным сбоем, никого не запирает.

**4. Таймаут TCP-коннекта не отличался от таймаута TLS/upgrade.** Оба приезжали безликим `Failed(String)`, поэтому на самый частый реальный таймаут (`TCP connect timed out` в логах #93) **не срабатывал ни один** из двух фолбэков: ни фронтинг, ни пропуск адреса. Теперь `OutboundError` несёт признак таймаута, а `WsConnectResult` различает фазы: фронтинг — только на зависший handshake (это подпись блокировки по SNI), пропуск адреса — только на несостоявшийся TCP-коннект (другой SNI на соединении, которое не открывается, не поможет).

**5. `--check` для воркера ничего не проверял.** Cloudflare отдаёт `101` из кода воркера ещё до того, как его `connect()` до датацентра отработает — в [образце воркера](https://github.com/valnesfjord/tg-ws-proxy-rs/blob/main/docs/CfWorker.md) `server.accept()` и `return new Response(null, {status: 101})` результата `connect()` не ждут. Проверка гоняла апгрейд и говорила `OK` на воркере, через который каждый живой клиент умирал мгновенно. Теперь через туннель уходит настоящий MTProto init, и туннель, который тут же закрывается, ловится.

**6. Туннель воркера открывался на локальный `--dc-ip`.** Воркер звонит из сети Cloudflare, где выбор адреса этим хостом не значит ничего, а протухший `--dc-ip` отправлял туннель в никуда. Апстрим всегда берёт встроенный адрес датацентра; `tcp_last_resort` у нас так уже делал.

## Скорость

Пул соединений для обоих Cloudflare-ярусов (воркер и `--cf-domain`), не больше одного простаивающего на `(ярус, DC, media)` и наполняется только от соединения, которое только что сработало — мёртвый воркер не передозванивается в фоне на каждом клиенте. Клиент, ходящий в Telegram через Cloudflare, платит два handshake (до края Cloudflare и дальше) перед первым байтом, а Telegram открывает отдельное соединение под каждую передачу медиа, так что на заблокированной сети эта цена ложится на каждую загрузку. `--pool-size 0` пулинг отключает.

С `--cf-balance` пул наполняется через следующий домен ротации, а не через тот, что ответил, — иначе балансировка тихо отменялась бы на каждом втором соединении.

`WsPool::get` получил вето `allow_refill`: адрес, который сейчас уходит в таймаут, больше не пред-коннектится в фоне (`--pool-size` обречённых коннектов на каждое клиентское соединение) — аналог `allow_pool_refill` из апстрима.

## Оптимизация

- `Config` живёт под `Arc`, а не глубоко клонируется на каждый приём соединения: с `--default-domains` это были десятки `String` на пути приёма соединения.
- Домены воркеров нормализуются один раз на старте, а не при каждом чтении с маршрутного пути.
- В туннельном режиме нет промежуточного `Vec` кадров на каждое чтение клиента.
- Префетч несёт один домен, а не копию всего списка кандидатов.

## Проверка

`cargo test` — 187 тестов, `cargo clippy --all-targets` чисто. Новый тест `a_worker_tunnel_never_emits_an_oversized_frame` гонит 3 MiB через `bridge_ws` и проверяет, что ни один кадр не выходит за одно чтение клиента; со старым поведением те же данные уходят одним сообщением на 3 MiB (`[64, 3145728]`) — тест реально ловит баг, а не просто зеленеет.

Живой прогон с `--cf-domain valnes.ru --default-domains --cf-balance --fronting-domain sprinthost.ru`: 251 сессия, 100 попаданий в пул, ноль ошибок, медиа-сессии DC2m по 92 секунды с реальным трафиком в обе стороны.

Правки проверены двумя независимыми ревью — на корректность и на сверку с исходниками апстрима; их находки (двойной проход CF-лестницы при `--cf-priority` + кулдаун, невозможность снять кулдаун, эскалация 2-секундной пробы в часовой бан, пул против `--cf-balance`) закрыты отдельным коммитом.

## Мажорная версия

2.0.0: публичный API изменился — `handle_client*` принимает `Arc<Config>`, `OutboundConnector::connect` возвращает `OutboundError`, `connect_ws_for_dc_with_outbound` — `WsAttempt`, у `WsConnectResult` новый вариант `ConnectTimedOut`, аксессоры доменов отдают заимствованные значения.

## Что осталось для полного паритета

Отдельными задачами, ни одно не блокирует это:

1. Фоновая ротация пула и backpressure на долив (v1.9.0): у апстрима задача каждые 5 с выселяет закрытые соединения, плюс backoff 60→3600 с на мёртвый DC. У нас пул доливается только реактивно, поэтому после `--pool-max-age` простоя он холодный.
2. `--buf-kb` — заглушка; апстрим ставит `SO_RCVBUF`/`SO_SNDBUF` в 256 KiB. Заметно на каналах с большим BDP.
3. Рандомизация доменов по умолчанию (v1.7.2) — у нас для этого нужен `--cf-balance`.
4. Поддержка тестовых DC (v1.9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
