### PR TITLE
perf: per-connection footprint + harness для замеров памяти

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +120,21 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -270,6 +300,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +466,12 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "heck"
@@ -647,6 +699,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +738,15 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -911,6 +987,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -980,6 +1069,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1104,13 +1206,14 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aes",
  "async-http-proxy",
  "cipher",
  "clap",
  "ctr",
+ "dhat",
  "futures-util",
  "hex",
  "hmac",
@@ -1153,6 +1256,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
@@ -1643,3 +1752,9 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"
@@ -69,6 +69,7 @@ rustls-pki-types = "1"
 webpki-roots = "0.26"
 # Async TLS streams (transitive dep of tokio-tungstenite; used for HTTPS GET in default_domains)
 tokio-rustls = "0.26"
+dhat = { version = "0.3.3", optional = true }
 
 [dev-dependencies]
 rcgen = "0.12"
@@ -78,3 +79,9 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
+
+[features]
+# Heap profiling build: swaps in dhat's allocator and shuts the accept loop
+# down after `TG_DHAT_SECS` (default 20) so the profile is written out.
+# See `examples/memtest.rs` for the load side.
+dhat = ["dep:dhat"]

--- a/examples/memtest.rs
+++ b/examples/memtest.rs
@@ -1,11 +1,15 @@
 //! Throwaway memory harness: fake Telegram WebSocket upstream + CONNECT proxy
 //! + N clients pulling media-sized frames through the proxy.
 //!
-//! `cargo run --release --example memtest -- <proxy-port> <clients> <frames> <frame-kib>`
+//! `cargo run --release --example memtest -- <proxy-addr> <clients> <frames> <frame-kib>`
 //!
-//! Point the proxy under test at this harness with:
-//!   --outbound-proxy http://127.0.0.1:<connect-port> --danger-accept-invalid-certs
-//!   --cf-domain fake.local --pool-size 0
+//! `proxy-addr` is where the proxy under test listens — `127.0.0.1:1443` for a
+//! local run, or `192.168.1.1:25565` to drive one on a router from a machine
+//! that has a Rust toolchain. Everything here binds `0.0.0.0`, so the proxy
+//! can reach it across the LAN:
+//!
+//!   --outbound-proxy http://<this-machine>:<connect-port>
+//!   --danger-accept-invalid-certs --cf-domain fake.local
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -25,7 +29,7 @@ async fn main() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let args: Vec<String> = std::env::args().collect();
-    let proxy_port: u16 = args[1].parse().unwrap();
+    let proxy_addr = args[1].clone();
     let clients: usize = args[2].parse().unwrap();
     let frames: usize = args[3].parse().unwrap();
     let frame_kib: usize = args[4].parse().unwrap();
@@ -41,8 +45,9 @@ async fn main() {
             .unwrap(),
     ));
 
-    let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let upstream_addr = upstream.local_addr().unwrap();
+    let upstream = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let upstream_port = upstream.local_addr().unwrap().port();
+    let upstream_addr = format!("127.0.0.1:{}", upstream_port);
     tokio::spawn(async move {
         loop {
             let Ok((stream, _)) = upstream.accept().await else {
@@ -80,13 +85,14 @@ async fn main() {
     });
 
     // ── CONNECT proxy: tunnels every target to the fake upstream ───────────
-    let connect = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let connect = TcpListener::bind("0.0.0.0:0").await.unwrap();
     let connect_addr = connect.local_addr().unwrap();
     tokio::spawn(async move {
         loop {
             let Ok((mut inbound, _)) = connect.accept().await else {
                 break;
             };
+            let upstream_addr = upstream_addr.clone();
             tokio::spawn(async move {
                 let mut buf = [0u8; 1024];
                 let mut seen = 0;
@@ -102,7 +108,7 @@ async fn main() {
                 if inbound.write_all(b"HTTP/1.1 200 OK\r\n\r\n").await.is_err() {
                     return;
                 }
-                let Ok(outbound) = TcpStream::connect(upstream_addr).await else {
+                let Ok(outbound) = TcpStream::connect(upstream_addr.as_str()).await else {
                     return;
                 };
                 let (mut ri, mut wi) = inbound.split();
@@ -119,7 +125,7 @@ async fn main() {
         }
     });
 
-    println!("CONNECT proxy on 127.0.0.1:{}", connect_addr.port());
+    println!("CONNECT proxy listening on port {}", connect_addr.port());
     println!("start the proxy under test now; clients connect in 10s");
     tokio::time::sleep(Duration::from_secs(10)).await;
 
@@ -127,7 +133,7 @@ async fn main() {
     let secret = hex::decode("0ea7201141bf2763a7dee49ba68eeb4c").unwrap();
     let mut held = Vec::new();
     for _ in 0..clients {
-        let Ok(mut stream) = TcpStream::connect(("127.0.0.1", proxy_port)).await else {
+        let Ok(mut stream) = TcpStream::connect(proxy_addr.as_str()).await else {
             continue;
         };
         let (handshake, _, _) = generate_client_handshake(&secret, 2, ProtoTag::PaddedIntermediate);

--- a/examples/memtest.rs
+++ b/examples/memtest.rs
@@ -1,0 +1,159 @@
+//! Throwaway memory harness: fake Telegram WebSocket upstream + CONNECT proxy
+//! + N clients pulling media-sized frames through the proxy.
+//!
+//! `cargo run --release --example memtest -- <proxy-port> <clients> <frames> <frame-kib>`
+//!
+//! Point the proxy under test at this harness with:
+//!   --outbound-proxy http://127.0.0.1:<connect-port> --danger-accept-invalid-certs
+//!   --cf-domain fake.local --pool-size 0
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::SinkExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::rustls::{self, ServerConfig};
+use tungstenite::Message;
+
+use tg_ws_proxy_rs::crypto::{ProtoTag, generate_client_handshake};
+
+#[tokio::main]
+async fn main() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let args: Vec<String> = std::env::args().collect();
+    let proxy_port: u16 = args[1].parse().unwrap();
+    let clients: usize = args[2].parse().unwrap();
+    let frames: usize = args[3].parse().unwrap();
+    let frame_kib: usize = args[4].parse().unwrap();
+
+    // ── Fake Telegram: TLS + WebSocket, streams `frames` big binary frames ──
+    let cert = rcgen::generate_simple_self_signed(vec!["fake.local".to_string()]).unwrap();
+    let cert_der = CertificateDer::from(cert.serialize_der().unwrap());
+    let key_der = PrivateKeyDer::try_from(cert.serialize_private_key_der()).unwrap();
+    let tls = TlsAcceptor::from(Arc::new(
+        ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert_der], key_der)
+            .unwrap(),
+    ));
+
+    let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = upstream.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = upstream.accept().await else {
+                break;
+            };
+            let tls = tls.clone();
+            tokio::spawn(async move {
+                let Ok(stream) = tls.accept(stream).await else {
+                    return;
+                };
+                // The proxy asks for the `binary` subprotocol, exactly as
+                // Telegram's endpoint expects; echo it back or it bails out.
+                let callback =
+                    |_req: &tungstenite::handshake::server::Request,
+                     mut response: tungstenite::handshake::server::Response| {
+                        response.headers_mut().insert(
+                            "Sec-WebSocket-Protocol",
+                            tungstenite::http::HeaderValue::from_static("binary"),
+                        );
+                        Ok(response)
+                    };
+                let Ok(mut ws) = tokio_tungstenite::accept_hdr_async(stream, callback).await else {
+                    return;
+                };
+                // Drain the proxy's relay init, then push media-sized frames.
+                let payload = vec![0x7Eu8; frame_kib * 1024];
+                for _ in 0..frames {
+                    if ws.send(Message::Binary(payload.clone())).await.is_err() {
+                        return;
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(120)).await;
+            });
+        }
+    });
+
+    // ── CONNECT proxy: tunnels every target to the fake upstream ───────────
+    let connect = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let connect_addr = connect.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut inbound, _)) = connect.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 1024];
+                let mut seen = 0;
+                while let Ok(n) = inbound.read(&mut buf[seen..]).await {
+                    if n == 0 {
+                        return;
+                    }
+                    seen += n;
+                    if buf[..seen].windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                if inbound.write_all(b"HTTP/1.1 200 OK\r\n\r\n").await.is_err() {
+                    return;
+                }
+                let Ok(outbound) = TcpStream::connect(upstream_addr).await else {
+                    return;
+                };
+                let (mut ri, mut wi) = inbound.split();
+                let (mut ro, mut wo) = tokio::io::split(outbound);
+                let _ = tokio::join!(
+                    async {
+                        let _ = tokio::io::copy(&mut ri, &mut wo).await;
+                    },
+                    async {
+                        let _ = tokio::io::copy(&mut ro, &mut wi).await;
+                    }
+                );
+            });
+        }
+    });
+
+    println!("CONNECT proxy on 127.0.0.1:{}", connect_addr.port());
+    println!("start the proxy under test now; clients connect in 10s");
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // ── Clients ────────────────────────────────────────────────────────────
+    let secret = hex::decode("0ea7201141bf2763a7dee49ba68eeb4c").unwrap();
+    let mut held = Vec::new();
+    for _ in 0..clients {
+        let Ok(mut stream) = TcpStream::connect(("127.0.0.1", proxy_port)).await else {
+            continue;
+        };
+        let (handshake, _, _) = generate_client_handshake(&secret, 2, ProtoTag::PaddedIntermediate);
+        if stream.write_all(&handshake).await.is_err() {
+            continue;
+        }
+        held.push(stream);
+    }
+    println!("{} clients connected, draining…", held.len());
+
+    // Drain everything the proxy relays down so the bridge keeps flowing.
+    let mut readers = Vec::new();
+    for mut stream in held {
+        readers.push(tokio::spawn(async move {
+            let mut buf = vec![0u8; 64 * 1024];
+            let mut total = 0usize;
+            while let Ok(n) = stream.read(&mut buf).await {
+                if n == 0 {
+                    break;
+                }
+                total += n;
+            }
+            total
+        }));
+    }
+
+    tokio::time::sleep(Duration::from_secs(20)).await;
+    println!("done");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,15 @@ use tg_ws_proxy_rs::{
     check, config::Config, default_domains, pool::WsPool, proxy, runtime::Runtime,
 };
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 #[tokio::main]
 async fn main() {
+    #[cfg(feature = "dhat")]
+    let _profiler = dhat::Profiler::new_heap();
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install rustls ring CryptoProvider");
@@ -281,6 +288,14 @@ async fn main() {
     const EMFILE: i32 = 24; // too many open files (per-process fd limit)
     const ENFILE: i32 = 23; // file table overflow (system-wide fd limit)
     let semaphore = Arc::new(Semaphore::new(max_connections));
+    #[cfg(feature = "dhat")]
+    let profile_deadline = tokio::time::Instant::now()
+        + Duration::from_secs(
+            std::env::var("TG_DHAT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(20),
+        );
     loop {
         // Block here when we are already at the connection limit.  Pending
         // TCP connections queue in the kernel backlog until capacity frees up.
@@ -289,7 +304,15 @@ async fn main() {
             .await
             .expect("semaphore closed unexpectedly");
 
-        match listener.accept().await {
+        #[cfg(feature = "dhat")]
+        let accepted = tokio::select! {
+            result = listener.accept() => result,
+            _ = tokio::time::sleep_until(profile_deadline) => break,
+        };
+        #[cfg(not(feature = "dhat"))]
+        let accepted = listener.accept().await;
+
+        match accepted {
             Ok((stream, peer_addr)) => {
                 let cfg = Arc::clone(&config);
                 let pool = pool.clone();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -53,7 +53,7 @@ use crate::runtime::Runtime;
 use crate::splitter::MsgSplitter;
 use crate::ws_client::{
     TgWsStream, WsAttempt, connect_cf_worker_ws_for_dc_with_outbound,
-    connect_cf_ws_for_dc_with_outbound, connect_ws_for_dc_with_outbound, media_tag, ws_send,
+    connect_cf_ws_for_dc_with_outbound, connect_ws_for_dc_with_outbound, media_tag,
 };
 
 type TcpReader = ReadHalf<TcpStream>;
@@ -491,68 +491,79 @@ pub async fn handle_client_with_runtime(
     let target_ip = config.dc_target_ip(dc_id).map(str::to_string);
 
     // ── Step 6: bridge whatever we ended up connected to ─────────────────
-    match select_upstream(&route, target_ip).await {
-        Some(Upstream::Ws { ws, framing }) => {
-            bridge_ws(
-                reader,
-                writer,
-                WsBridgeParams {
-                    label: &label,
-                    ws,
-                    framing,
-                    relay_init,
-                    ciphers,
-                    proto,
-                    dc: dc_id,
-                    is_media,
-                },
-            )
-            .await;
-        }
-        Some(Upstream::Mtproto(conn)) => {
-            let ConnectionCiphers {
-                clt_dec, clt_enc, ..
-            } = ciphers;
-
-            bridge_relay(
-                reader,
-                writer,
-                RelayParams {
-                    label: &label,
-                    rem_reader: conn.reader,
-                    rem_writer: conn.writer,
-                    ciphers: ConnectionCiphers {
-                        clt_dec,
-                        clt_enc,
-                        tg_enc: conn.enc,
-                        tg_dec: conn.dec,
+    // Boxed so the whole fallback ladder — every TLS handshake and WebSocket
+    // upgrade it can attempt — lives in a temporary allocation that is freed
+    // once a route is picked, instead of inflating the state machine that
+    // every connection then holds for its entire session.
+    // Boxed as one step: the bridge that runs for the rest of the session
+    // is then its own allocation, sized to the path actually taken, rather
+    // than every connection carrying a state machine as large as the
+    // widest branch plus the whole fallback ladder that chose it.
+    Box::pin(async {
+        match Box::pin(select_upstream(&route, target_ip)).await {
+            Some(Upstream::Ws { ws, framing }) => {
+                bridge_ws(
+                    reader,
+                    writer,
+                    WsBridgeParams {
+                        label: &label,
+                        ws,
+                        framing,
+                        relay_init,
+                        ciphers,
+                        proto,
+                        dc: dc_id,
+                        is_media,
                     },
-                    faketls: conn.faketls,
-                    dc: dc_id,
-                    is_media,
-                },
-            )
-            .await;
+                )
+                .await;
+            }
+            Some(Upstream::Mtproto(conn)) => {
+                let ConnectionCiphers {
+                    clt_dec, clt_enc, ..
+                } = ciphers;
+
+                bridge_relay(
+                    reader,
+                    writer,
+                    RelayParams {
+                        label: &label,
+                        rem_reader: conn.reader,
+                        rem_writer: conn.writer,
+                        ciphers: ConnectionCiphers {
+                            clt_dec,
+                            clt_enc,
+                            tg_enc: conn.enc,
+                            tg_dec: conn.dec,
+                        },
+                        faketls: conn.faketls,
+                        dc: dc_id,
+                        is_media,
+                    },
+                )
+                .await;
+            }
+            Some(Upstream::Tcp(dst)) => {
+                bridge_tcp(
+                    reader,
+                    writer,
+                    TcpBridgeParams {
+                        label: &label,
+                        dst: &dst,
+                        relay_init: &relay_init,
+                        ciphers,
+                        dc: dc_id,
+                        is_media,
+                        connect_timeout: route.timeouts.tcp_fallback,
+                        runtime: Arc::clone(&runtime),
+                    },
+                )
+                .await;
+            }
+            None => {}
         }
-        Some(Upstream::Tcp(dst)) => {
-            bridge_tcp(
-                reader,
-                writer,
-                TcpBridgeParams {
-                    label: &label,
-                    dst: &dst,
-                    relay_init: &relay_init,
-                    ciphers,
-                    dc: dc_id,
-                    is_media,
-                    connect_timeout: route.timeouts.tcp_fallback,
-                    runtime: Arc::clone(&runtime),
-                },
-            )
-            .await;
-        }
-        None => {}
-    }
+    })
+    .await;
 }
 
 // ─── Routing ─────────────────────────────────────────────────────────────────
@@ -1270,7 +1281,7 @@ struct WsBridgeParams<'a> {
 async fn bridge_ws(reader: ClientReader, writer: ClientWriter, params: WsBridgeParams<'_>) {
     let WsBridgeParams {
         label,
-        mut ws,
+        ws,
         framing,
         relay_init,
         ciphers,
@@ -1278,12 +1289,6 @@ async fn bridge_ws(reader: ClientReader, writer: ClientWriter, params: WsBridgeP
         dc,
         is_media,
     } = params;
-
-    // Send the relay init packet to Telegram before bridging.
-    if let Err(e) = ws_send(&mut ws, relay_init.to_vec()).await {
-        warn!("[{}] failed to send relay init: {}", label, e);
-        return;
-    }
 
     let ConnectionCiphers {
         mut clt_dec,
@@ -1302,8 +1307,19 @@ async fn bridge_ws(reader: ClientReader, writer: ClientWriter, params: WsBridgeP
 
     let upload = tokio::spawn({
         let counters = Arc::clone(&counters);
+        let label = label.to_string();
 
         async move {
+            // The relay init opens the conversation with Telegram, and it is
+            // sent from here rather than before the split so that the caller's
+            // state machine — the one allocation that lives as long as the
+            // session — never has to hold the WebSocket (and the TLS session
+            // inside it) across an await.
+            if let Err(e) = ws_sink.send(Message::Binary(relay_init.to_vec())).await {
+                warn!("[{}] failed to send relay init: {}", label, e);
+                return;
+            }
+
             let mut reader = reader;
             let mut buf = vec![0u8; CLIENT_READ_BUF_SIZE];
 

--- a/src/ws_client.rs
+++ b/src/ws_client.rs
@@ -38,6 +38,7 @@ use tokio_tungstenite::{
 use tracing::{debug, warn};
 use tungstenite::Error as WsError;
 use tungstenite::Message;
+use tungstenite::protocol::WebSocketConfig;
 
 /// A live WebSocket connection to a Telegram DC.
 pub type TgWsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -306,10 +307,45 @@ where
             .connect(server_name, tcp)
             .await
             .map_err(WsError::Io)?;
-        client_async_with_config(request, MaybeTlsStream::Rustls(tls_stream), None).await
+        client_async_with_config(
+            request,
+            MaybeTlsStream::Rustls(tls_stream),
+            Some(ws_config()),
+        )
+        .await
     } else {
         let connector = build_tls_connector(skip_tls_verify);
-        client_async_tls_with_config(request, tcp, None, Some(connector)).await
+        client_async_tls_with_config(request, tcp, Some(ws_config()), Some(connector)).await
+    }
+}
+
+/// Ceiling on a single WebSocket frame from Telegram, and on a message
+/// reassembled from them.
+///
+/// tungstenite defaults to 16 MiB and 64 MiB, and grows a per-connection input
+/// buffer to whatever it has actually seen — so the frame size is what a
+/// connection's memory settles at, and the default ceiling is far above
+/// anything Telegram sends. One MTProto packet arrives per message here, and
+/// the largest is a media part: `upload.getFile` caps a part at 1 MiB, so
+/// 4 MiB leaves generous headroom for transport framing while keeping a
+/// misbehaving or hostile upstream from parking megabytes per connection.
+const WS_MAX_FRAME: usize = 4 << 20;
+
+/// Bytes tungstenite may queue before it flushes to the socket.
+///
+/// Its default is 128 KiB, sized for callers that batch many small messages.
+/// Both bridge directions here `await` each send, so the queue never usefully
+/// exceeds one message — the smaller threshold just keeps a burst from
+/// growing the buffer and holding that capacity for the connection's life.
+const WS_WRITE_BUFFER: usize = 16 * 1024;
+
+/// Frame limits applied to every WebSocket this proxy opens.
+fn ws_config() -> WebSocketConfig {
+    WebSocketConfig {
+        write_buffer_size: WS_WRITE_BUFFER,
+        max_frame_size: Some(WS_MAX_FRAME),
+        max_message_size: Some(WS_MAX_FRAME),
+        ..WebSocketConfig::default()
     }
 }
 


### PR DESCRIPTION
Частично закрывает #97 — и заодно даёт воспроизводимый способ мерить остальное.

## Как измерялось

Добавлен `examples/memtest.rs`: поддельный WebSocket-апстрим Telegram (TLS + `binary` subprotocol), CONNECT-прокси, который заворачивает на него любой адрес, и N клиентов, тянущих кадры медийного размера. Плюс сборка `--features dhat` для профиля кучи. Без этого «оптимизация ОЗУ» — гадание: mimalloc, например, я тоже попробовал, и он оказался **хуже** (16.6 → 23.5 МБ на том же сценарии), поэтому в диффе его нет.

```
cargo run --release --example memtest -- <порт> <клиентов> <кадров> <кадр-KiB>
```

## Что уменьшилось

**Футура соединения: 20 704 → 1 632 байта.** Каждое соединение держало на всю сессию один стейт-машин размером с самую широкую ветку бриджа плюс всю лестницу фолбэков, которая эту ветку выбрала — всё заинлайнено в одну футуру. Теперь лестница и бридж боксятся по отдельности, и сессия держит только реально выбранную ветку. Отправка relay init переехала в upload-таск, чтобы WebSocket (а внутри него — TLS-сессия) вообще не жил через await в долгоживущей футуре.

60 простаивающих соединений: **12.6 → 11.9 МБ RSS**.

**Потолок кадра и сообщения: 4 MiB вместо дефолтных 16 MiB и 64 MiB.** В одном сообщении приходит один MTProto-пакет, самый большой — часть медиа на 1 MiB, так что запас щедрый. Но входной буфер tungstenite запоминает максимум, который видел, и держит его до конца соединения — со старым потолком один странный кадр мог припарковать мегабайты на соединение навсегда.

**Буфер записи: 128 → 16 KiB.** Обе стороны бриджа делают `await` на каждой отправке, так что очередь никогда осмысленно не превышает одно сообщение.

## Что НЕ изменилось

Память во время медиа — не изменилась. На сценарии «20 соединений × 128 KiB кадры»: было 16.0 МБ, стало 16.1 МБ. На 512 KiB: 34.8 → 36.6 МБ.

Профиль кучи объясняет, почему: при 128 KiB кадрах в пике **6.0 MiB живой кучи против 16 МБ RSS**, и живая часть — это почти целиком блоки ровно по размеру кадра: по одному удерживает входной буфер WebSocket на каждое соединение, ещё один держится в полёте, пока клиент вычитывает. То есть ~2 кадра на активное соединение, и сверху ~2.6× удержания аллокатором.

Оба слагаемых лежат вне этого диффа:

1. **Буферизация кадра целиком** — устройство `Message`-API tungstenite: кадр собирается полностью, прежде чем его отдадут. Чтобы это убрать, нужен стриминговый разбор кадров, то есть другой слой WebSocket.
2. **Удержание аллокатором** — самая большая одиночная составляющая (10 из 16 МБ на macOS). Проверять надо на musl: все Linux-цели релиза musl-овые, а его mallocng ведёт себя под таким churn'ом иначе, чем libmalloc. У меня musl-окружения нет, вслепую менять аллокатор не стал.

Живой прогон на реальном клиенте с этой сборкой: медиа-сессия **↓68.9 МБ за 40.9 с** через CF-путь — новые потолки настоящий трафик не режут.

187 тестов, clippy чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
