### PR TITLE
feat: UPX-ассеты релиза для роутеров + разбор README на гайды

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,90 @@ jobs:
                   cp "target/${{ matrix.target }}/release/tg-ws-proxy" "${TMPDIR}/tg-ws-proxy"
                   tar -C "${TMPDIR}" -czf "${NAME}.tar.gz" tg-ws-proxy
                   gh release upload "$TAG" "${NAME}.tar.gz" --clobber
+
+    # Extra UPX-packed assets for flash-constrained devices (OpenWrt routers).
+    #
+    # These do not replace the plain assets: packing trades RAM for flash. A
+    # normal ELF maps its text from the file, so only the working set is
+    # resident and those pages can be evicted under pressure; the UPX stub
+    # decompresses the whole image into anonymous memory instead, which on a
+    # router with no swap stays resident for the life of the process. Good deal
+    # on a 128 MB device with 8 MB of flash, bad one on a 32 MB device — so the
+    # choice belongs to whoever is doing the flashing.
+    #
+    # Windows and macOS are deliberately excluded: UPX-packed PE files trip
+    # antivirus heuristics, which is unacceptable for a censorship-circumvention
+    # tool, and packing a Mach-O invalidates its signature so arm64 macOS
+    # refuses to run it at all.
+    compress-assets:
+        needs: upload-assets
+        # Not `success()`: upload-assets covers Windows and macOS too, and a
+        # hiccup there should not silently drop every `-upx` asset. Each leg
+        # below fails on its own if its plain asset never made it to the release.
+        if: ${{ !cancelled() }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - target: mipsel-unknown-linux-musl
+                      qemu: qemu-mipsel-static
+                    - target: mips-unknown-linux-musl
+                      qemu: qemu-mips-static
+                    - target: armv7-unknown-linux-musleabihf
+                      qemu: qemu-arm-static
+                    - target: aarch64-unknown-linux-musl
+                      qemu: qemu-aarch64-static
+                    - target: x86_64-unknown-linux-musl
+                      qemu: qemu-x86_64-static
+        steps:
+            - name: Install UPX and qemu-user-static
+              env:
+                  UPX_VERSION: 5.2.0
+                  UPX_SHA256: 3db5d3294707439db97866feab8d75d800f028f48481a40547411824da4288a1
+              shell: bash
+              run: |
+                  set -euxo pipefail
+                  curl -fsSL -o upx.tar.xz \
+                      "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz"
+                  echo "${UPX_SHA256}  upx.tar.xz" | sha256sum -c -
+                  tar -xJf upx.tar.xz
+                  sudo install -m 0755 "upx-${UPX_VERSION}-amd64_linux/upx" /usr/local/bin/upx
+                  sudo apt-get update
+                  sudo apt-get install -y qemu-user-static
+
+            - name: Pack, verify and upload
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
+              run: |
+                  set -euxo pipefail
+                  TAG="${GITHUB_REF_NAME}"
+                  NAME="tg-ws-proxy-${{ matrix.target }}"
+                  WORK="$(mktemp -d)"
+
+                  gh release download "$TAG" --repo "${GITHUB_REPOSITORY}" \
+                      --pattern "${NAME}.tar.gz" --dir "$WORK"
+                  tar -C "$WORK" -xzf "${WORK}/${NAME}.tar.gz"
+                  test -f "${WORK}/tg-ws-proxy"
+
+                  # Smoke-test the stock binary first. If this fails the emulator
+                  # is the problem, not UPX, and the post-pack check below would
+                  # be measuring nothing.
+                  ${{ matrix.qemu }} "${WORK}/tg-ws-proxy" --help > "${WORK}/help-plain.txt"
+                  grep -q "Usage: tg-ws-proxy" "${WORK}/help-plain.txt"
+                  BEFORE="$(stat -c %s "${WORK}/tg-ws-proxy")"
+
+                  upx -9 --lzma "${WORK}/tg-ws-proxy"
+                  upx -t "${WORK}/tg-ws-proxy"
+
+                  # `upx -t` only proves the payload round-trips. The failure that
+                  # actually reaches users is a stub that packs clean and then dies
+                  # on the target ABI, so run the packed binary for real.
+                  ${{ matrix.qemu }} "${WORK}/tg-ws-proxy" --help > "${WORK}/help-packed.txt"
+                  grep -q "Usage: tg-ws-proxy" "${WORK}/help-packed.txt"
+                  AFTER="$(stat -c %s "${WORK}/tg-ws-proxy")"
+                  echo "${{ matrix.target }}: ${BEFORE} -> ${AFTER} bytes on flash"
+
+                  tar -C "$WORK" -czf "${NAME}-upx.tar.gz" tg-ws-proxy
+                  gh release upload "$TAG" "${NAME}-upx.tar.gz" --clobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,9 @@ src/
 
 tests/                   Integration tests (one file per subsystem, mirrors src/ module names)
 tests/common/mod.rs      Shared integration fixtures (fake HTTP CONNECT proxy, proxy-connection driver)
-docs/                    CfProxy.md, CfWorker.md — setup guides for Cloudflare-based fallback routing
+docs/                    User-facing guides. README stays an overview and links here rather than growing:
+                         Fallbacks.md (routing tiers), Building.md (cross-compiling, UPX), Deployment.md
+                         (Docker, OpenWrt, env vars), CfProxy.md + CfWorker.md (Cloudflare setup)
 ```
 
 Modules whose *private* internals need testing keep a `#[cfg(test)] mod tests;` in a sibling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,12 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bitflags"
-version = "2.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,16 +296,6 @@ name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -617,15 +601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,29 +658,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "pem"
@@ -871,15 +823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,12 +891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,16 +955,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "slab"
@@ -1104,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "aes",
  "async-http-proxy",
@@ -1201,9 +1128,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"
@@ -17,7 +17,18 @@ path = "src/main.rs"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+# Only the features actually reached from src/ and tests/. `full` additionally
+# pulls in fs/process/signal; LTO strips the unused code either way (~16 KB), so
+# this is about the dependency tree, not the binary — it drops parking_lot,
+# signal-hook-registry and six more transitive crates.
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "net",
+    "io-util",
+    "time",
+    "sync",
+] }
 
 # WebSocket protocol with TLS support
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }

--- a/README.md
+++ b/README.md
@@ -28,61 +28,43 @@ Telegram Desktop → MTProto (TCP 1443) → tg-ws-proxy-rs → WS (TLS 443) → 
 
 ### Pre-built binaries
 
-Download from the [Releases](../../releases) page.
+Download from the [Releases](../../releases) page. Linux musl targets also ship
+a `-upx` variant that is ~70% smaller on disk, for routers where flash is
+tight — see [docs/Building.md](docs/Building.md#shrinking-the-binary-for-flash-constrained-devices)
+for the RAM trade-off that comes with it.
+
+### Docker
+
+Published to Docker Hub as
+[`valnesfjord/tg-ws-proxy-rs`](https://hub.docker.com/r/valnesfjord/tg-ws-proxy-rs)
+(`linux/amd64` + `linux/arm64`):
+
+```bash
+docker run -d --name tg-ws-proxy -p 1443:1443 valnesfjord/tg-ws-proxy-rs
+```
+
+Set `TG_SECRET` so the secret survives restarts, and `--link-ip` so the printed
+`tg://` link points at a reachable address — see
+[docs/Deployment.md](docs/Deployment.md#docker).
 
 ### Build from source
 
 ```bash
-# Debug build
-cargo build
-
-# Optimised release build
 cargo build --release
-
-# Static binary for Linux x86_64 (e.g. for Docker scratch images)
-rustup target add x86_64-unknown-linux-musl
-cargo build --release --target x86_64-unknown-linux-musl
 ```
 
-The release binary is at `target/release/tg-ws-proxy` (or
-`target/<target>/release/tg-ws-proxy` for cross-compiled targets).
+The binary lands in `target/release/tg-ws-proxy`. Cross-compiling for OpenWrt
+(MIPS/ARM/ARM64) is covered in [docs/Building.md](docs/Building.md).
 
-## Cross-platform builds with `cargo-zigbuild`
+### Telegram Desktop setup
 
-[`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) uses the Zig
-compiler as a drop-in C cross-linker so you can build for every platform from
-a single Linux or macOS host without installing any platform SDKs.
+1. **Settings → Advanced → Connection type → Use custom proxy**
+2. Add MTProto proxy:
+   - **Server:** `127.0.0.1`
+   - **Port:** `1443` (or your `--port`)
+   - **Secret:** shown in the proxy startup log
 
-```bash
-# Install cargo-zigbuild and Zig
-pip install ziglang        # or: brew install zig
-cargo install cargo-zigbuild
-
-# Add all required Rust targets in one shot
-rustup target add \
-  x86_64-unknown-linux-musl \
-  aarch64-unknown-linux-musl \
-  armv7-unknown-linux-musleabihf \
-  mipsel-unknown-linux-musl \
-  x86_64-apple-darwin \
-  aarch64-apple-darwin \
-  x86_64-pc-windows-gnu
-
-# Build for all platforms
-cargo zigbuild --release --target x86_64-unknown-linux-musl       # Linux x86-64 (musl static)
-cargo zigbuild --release --target aarch64-unknown-linux-musl      # Linux / OpenWrt ARM64
-cargo zigbuild --release --target armv7-unknown-linux-musleabihf  # OpenWrt ARMv7
-cargo zigbuild --release --target mipsel-unknown-linux-musl       # OpenWrt MIPS LE
-cargo zigbuild --release --target x86_64-apple-darwin             # macOS Intel
-cargo zigbuild --release --target aarch64-apple-darwin            # macOS Apple Silicon
-cargo zigbuild --release --target x86_64-pc-windows-gnu           # Windows x86-64
-```
-
-> **Note:** Building macOS targets (`*-apple-darwin`) requires the macOS SDK
-> (XCode Command Line Tools). On Linux you can use
-> [`osxcross`](https://github.com/tpoechtrager/osxcross) to supply the SDK
-> and then set `SDKROOT` / `MACOSX_DEPLOYMENT_TARGET` appropriately before
-> running `cargo zigbuild`.
+Or use the `tg://proxy?...` link that is printed on startup.
 
 ## Usage
 
@@ -94,19 +76,19 @@ tg-ws-proxy [OPTIONS]
 |---|---|---|
 | `--port <PORT>` | `1443` | Listen port |
 | `--host <HOST>` | auto-detected | Listen address. Binds `0.0.0.0` if a LAN IP is detected (so it matches the auto-detected link IP below), otherwise `127.0.0.1` |
-| `--link-ip <IP>` | auto-detected | IP shown in the `tg://` link (see [Router deployment](#router-deployment)) |
+| `--link-ip <IP>` | auto-detected | IP shown in the `tg://` link (see [Router deployment](docs/Deployment.md#router-deployment)) |
 | `--secret <HEX>` | random | 32 hex-char MTProto secret (repeatable / comma-separated for per-user secrets) |
 | `--listen-faketls-domain <DOMAIN>` | — | Accept inbound clients with `ee` FakeTLS and advertise this SNI domain in the link |
 | `--dc-ip <DC:IP>` | DC2 + DC4 | Target IP per DC (repeatable); omit when using `--cf-domain` to let CF proxy handle all DCs |
 | `--buf-kb <KB>` | `256` | Socket buffer size (accepted but currently unused) |
 | `--pool-size <N>` | `4` | Pre-warmed WS connections per DC |
-| `--cf-domain <DOMAIN>` | — | Cloudflare-proxied domain(s) for alternative WS routing, comma-separated (see [CF Proxy](#cloudflare-proxy)) |
-| `--cf-worker-domain <DOMAIN>` | — | Cloudflare Worker domain(s) for TCP-tunnel fallback, comma-separated/repeatable (see [Cloudflare Worker](#cloudflare-worker)) |
-| `--default-domains` | off | Fetch and use the built-in CF proxy domain list from GitHub (no Cloudflare setup needed, see [Default domains](#default-domains)) |
-| `--cf-priority` | off | Try the CF tiers (Worker, then CF proxy) **before** direct WS for all DCs (see [CF Proxy](#cloudflare-proxy)) |
-| `--cf-balance` | off | Round-robin load balance across multiple `--cf-domain` and `--cf-worker-domain` values (see [CF Proxy](#cloudflare-proxy)) |
+| `--cf-domain <DOMAIN>` | — | Cloudflare-proxied domain(s) for alternative WS routing, comma-separated |
+| `--cf-worker-domain <DOMAIN>` | — | Cloudflare Worker domain(s) for TCP-tunnel fallback, comma-separated/repeatable |
+| `--default-domains` | off | Fetch and use the built-in CF proxy domain list from GitHub (no Cloudflare setup needed) |
+| `--cf-priority` | off | Try the CF tiers (Worker, then CF proxy) **before** direct WS for all DCs |
+| `--cf-balance` | off | Round-robin load balance across multiple `--cf-domain` and `--cf-worker-domain` values |
 | `--ip-fail-cooldown <SECS>` | `3600` | How long to skip the direct WS path for a `--dc-ip` address whose TCP connect timed out, when a Cloudflare/upstream fallback is configured |
-| `--fronting-domain <DOMAIN>` | off | Domain-fronting fallback SNI, e.g. `sprinthost.ru` (see [Domain fronting](#domain-fronting)) |
+| `--fronting-domain <DOMAIN>` | off | Domain-fronting fallback SNI, e.g. `sprinthost.ru` |
 | `--fronting-cooldown <SECS>` | `1800` | How long the fronting fallback stays active after it last succeeded |
 | `--fronting-fail-cooldown <SECS>` | `60` | How long to stop retrying fronting after it fails for a DC (protects against networks that block Telegram's DC IPs outright, where fronting can never succeed) |
 | `--max-connections <N>` | auto | Max concurrent client connections (auto-computed from `ulimit -n`) |
@@ -114,21 +96,29 @@ tg-ws-proxy [OPTIONS]
 | `--outbound-proxy <URL>` | — | Proxy for all outgoing connections: `http://`, `socks5://`, or `socks5h://`; `https://` proxy URLs are not supported |
 | `--no-outbound-proxy` | off | Ignore standard outbound proxy environment variables |
 | `--no-proxy <LIST>` | — | Comma-separated host bypass list for `--outbound-proxy` |
+| `--check` | off | Test every configured CF domain and MTProto proxy, print OK/FAIL with latency, then exit `0` if all pass and `1` otherwise |
 | `--log-file <PATH>` | — | Write logs to a file instead of stderr (no ANSI color codes) |
 | `-q / --quiet` | off | Suppress all log output |
 | `-v / --verbose` | off | Debug logging |
 | `--danger-accept-invalid-certs` | off | Skip TLS verification |
 
-Every flag has a matching environment variable (`TG_PORT`, `TG_HOST`,
-`TG_SECRET`, `TG_BUF_KB`, `TG_POOL_SIZE`, `TG_MAX_CONNECTIONS`, `TG_QUIET`,
-`TG_VERBOSE`, `TG_SKIP_TLS_VERIFY`, `TG_LINK_IP`, `TG_LISTEN_FAKETLS_DOMAIN`, `TG_MTPROTO_PROXY`,
-`TG_LOG_FILE`, `TG_CF_DOMAIN`, `TG_CF_WORKER_DOMAIN`, `TG_CF_PRIORITY`,
-`TG_CF_BALANCE`, `TG_DEFAULT_DOMAINS`, `TG_OUTBOUND_PROXY`, `TG_NO_OUTBOUND_PROXY`, `TG_NO_PROXY`,
-`TG_FRONTING_DOMAIN`, `TG_FRONTING_COOLDOWN`, `TG_FRONTING_FAIL_COOLDOWN`).
-When `TG_OUTBOUND_PROXY` is not set, standard `HTTPS_PROXY`, `ALL_PROXY`,
-`HTTP_PROXY` and `NO_PROXY` environment variables are also honored. `https://`
-proxy URLs are skipped when discovered from the standard environment if a later
-supported `http://`, `socks5://`, or `socks5h://` fallback is present.
+Every flag has a matching `TG_*` environment variable (`TG_PORT`, `TG_HOST`,
+`TG_SECRET`, …) — the full list is in
+[docs/Deployment.md](docs/Deployment.md#configuration-via-environment).
+
+On startup the proxy prints a `tg://proxy?...` link you can paste into
+Telegram Desktop to configure it automatically. With `--listen-faketls-domain`,
+the printed link uses `secret=ee<key><domain_hex>`; otherwise it uses the
+classic `dd<key>` padded MTProto secret.
+
+To issue separate credentials per user, pass multiple `--secret` values — the
+proxy accepts all of them and prints an individual `tg://` link for each:
+
+```bash
+tg-ws-proxy --host 0.0.0.0 --port 443 \
+  --secret 11111111111111111111111111111111 \
+  --secret 22222222222222222222222222222222
+```
 
 ### Examples
 
@@ -139,46 +129,23 @@ tg-ws-proxy
 # Custom port and extra DCs
 tg-ws-proxy --port 9050 --dc-ip 1:149.154.175.205 --dc-ip 2:149.154.167.220
 
-# With upstream MTProto proxy fallback
-tg-ws-proxy --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef1234567890
-
-# With Cloudflare proxy domain (WS fallback via Cloudflare CDN)
-tg-ws-proxy --cf-domain yourdomain.com
-
-# With Cloudflare Worker (free workers.dev TCP tunnel fallback)
-tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev
-
-# CF proxy only: omit --dc-ip so CF proxy handles all DCs
-tg-ws-proxy --cf-domain yourdomain.com --cf-priority
-
 # Use default CF domains from GitHub — no Cloudflare setup required
 tg-ws-proxy --default-domains
 
 # Default domains + CF priority (try CF first, fall back to direct WS)
 tg-ws-proxy --default-domains --cf-priority
 
-# Default domains + your own domain (yours goes first)
-tg-ws-proxy --cf-domain yourdomain.com --default-domains
-
-# Multiple CF domains (tried in order) with CF priority over direct WS
-tg-ws-proxy --cf-domain proxy.net,example.com --cf-priority
+# Your own Cloudflare-proxied domain
+tg-ws-proxy --cf-domain yourdomain.com
 
 # Multiple CF domains with round-robin load balancing
 tg-ws-proxy --cf-domain proxy.net,example.com --cf-balance
 
-# CF balance + priority: round-robin across CF domains, tried before direct WS
-tg-ws-proxy --cf-domain proxy.net,example.com --cf-balance --cf-priority
+# Free workers.dev TCP tunnel fallback
+tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev
 
-# CF priority: CF proxy is tried first, falls back to direct WS on failure
-tg-ws-proxy --dc-ip 2:149.154.167.220 --cf-domain yourdomain.com --cf-priority
-
-# Multiple upstream proxies (tried in order until one succeeds)
-tg-ws-proxy \
-  --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef1234567890 \
-  --mtproto-proxy other.example.net:8888:dddeadbeef01234567deadbeef01234567
-
-# Route all outbound connections through an HTTP CONNECT proxy
-tg-ws-proxy --outbound-proxy http://user:pass@192.168.1.1:3128
+# Upstream MTProto proxy fallback
+tg-ws-proxy --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef1234567890
 
 # Route all outbound connections through a SOCKS5 proxy with remote DNS
 tg-ws-proxy --outbound-proxy socks5h://user:pass@192.168.1.1:1080
@@ -189,453 +156,11 @@ tg-ws-proxy --host 0.0.0.0
 # Public home server: inbound ee FakeTLS, backend still WSS to Telegram Web
 tg-ws-proxy --host 0.0.0.0 --port 443 --listen-faketls-domain www.yandex.ru
 
-# Equivalent: pass a full ee secret directly
-tg-ws-proxy --host 0.0.0.0 --port 443 --secret ee<32-hex-key><hex-encoded-domain>
-
-# Verbose logging
-tg-ws-proxy -v
-
 # Log to a file instead of stderr (no garbled ANSI codes — useful on Windows)
 tg-ws-proxy --log-file proxy.log
 
 # All options via environment variables (useful for Docker / systemd)
 TG_PORT=1443 TG_SECRET=deadbeef... tg-ws-proxy
-```
-
-On startup the proxy prints a `tg://proxy?...` link you can paste into
-Telegram Desktop to configure it automatically. With `--listen-faketls-domain`,
-the printed link uses `secret=ee<key><domain_hex>`; otherwise it uses the
-classic `dd<key>` padded MTProto secret.
-
-To issue separate credentials per user, pass multiple `--secret` values:
-
-```bash
-tg-ws-proxy --host 0.0.0.0 --port 443 \
-  --secret 11111111111111111111111111111111 \
-  --secret 22222222222222222222222222222222
-```
-
-The proxy will accept all configured secrets and print an individual `tg://`
-link for each additional secret.
-
-### Inbound FakeTLS listener
-
-For public home servers where DPI blocks raw inbound MTProto, enable inbound
-FakeTLS:
-
-```bash
-tg-ws-proxy --host 0.0.0.0 --port 443 --listen-faketls-domain www.yandex.ru
-```
-
-This changes only the client-facing transport:
-
-```
-Telegram client → ee FakeTLS → tg-ws-proxy-rs → WSS/TLS → kws*.web.telegram.org
-```
-
-The proxy accepts the TLS ClientHello, validates the FakeTLS HMAC, sends a
-synthetic TLS ServerHello, unwraps TLS Application Data records, and then
-passes the recovered MTProto init into the existing WebSocket backend path.
-
-### Upstream MTProto proxy fallback
-
-When WebSocket connections to Telegram are blocked, the proxy can route
-traffic through an external MTProto proxy before falling back to direct TCP:
-
-```
-WS (preferred) → upstream MTProto proxy → direct TCP (last resort)
-```
-
-Pass one or more `--mtproto-proxy HOST:PORT:SECRET` flags (or a
-comma-separated list in `TG_MTPROTO_PROXY`).  Proxies are tried in the order
-given; if one fails it enters a 60-second cooldown so subsequent connections
-skip it without delay.
-
-```bash
-# Padded-intermediate proxy (dd prefix)
-tg-ws-proxy --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef1234567890
-
-# FakeTLS proxy (ee prefix — domain-fronting transport)
-tg-ws-proxy --mtproto-proxy proxy.example.com:443:ee<32-hex-key><hex-encoded-hostname>
-
-# Multiple proxies (tried in order until one succeeds)
-tg-ws-proxy \
-  --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef1234567890 \
-  --mtproto-proxy other.example.net:8888:dddeadbeef01234567deadbeef01234567
-
-# Or via environment variable (comma-separated)
-TG_MTPROTO_PROXY="proxy.example.com:443:ddabcdef1234...,other.example.net:8888:dddeadbeef..." tg-ws-proxy
-```
-
-> **ℹ️ Secret format — pass the secret exactly as shown in the `tg://proxy` link**
->
-> Public MTProto proxies advertise secrets with a 1-byte prefix that tells the
-> proxy which transport mode to use.  **Copy the full secret as-is — prefix included:**
->
-> | Prefix | Meaning | Example |
-> |--------|---------|---------|
-> | `dd` | Padded-intermediate transport | `ddabcdef1234567890abcdef1234567890` |
-> | `ee` | FakeTLS (domain-fronting) transport | `ee` + 32 hex key chars + hex-encoded hostname |
-> | *(none)* | Plain transport (legacy, 32 hex chars) | `abcdef1234567890abcdef1234567890` |
->
-> In the `tg://proxy?server=...&secret=` link the `secret=` value already
-> contains the correct prefix.  Copy everything after `secret=` and pass it
-> directly to `--mtproto-proxy`.
-
-### Outbound proxy
-
-If the host running tg-ws-proxy-rs can reach the internet only through another
-proxy, route all outgoing connections through `--outbound-proxy`:
-
-```bash
-tg-ws-proxy --outbound-proxy http://user:pass@192.168.1.1:3128
-tg-ws-proxy --outbound-proxy socks5://user:pass@192.168.1.1:1080
-tg-ws-proxy --outbound-proxy socks5h://user:pass@192.168.1.1:1080
-```
-
-`socks5://` resolves hostnames locally before sending the CONNECT request.
-`socks5h://` sends the hostname to the SOCKS proxy and lets it resolve DNS
-remotely.  The setting applies to direct Telegram WS, Cloudflare proxy,
-Cloudflare Worker, upstream MTProto proxies, direct TCP fallback, `--check`,
-and the `--default-domains` fetch.
-
-The same setting can be supplied through `TG_OUTBOUND_PROXY`.  If it is not
-set, standard `HTTPS_PROXY`, `ALL_PROXY`, `HTTP_PROXY` variables are used in
-that order.  `https://` proxy URLs from those standard environment variables
-are ignored when a later supported fallback exists; an explicit
-`--outbound-proxy https://...` remains an error.
-
-Use `TG_OUTBOUND_PROXY=direct` (also accepts `none` or `off`) or
-`--no-outbound-proxy` to disable environment proxy discovery explicitly. Use
-`--no-proxy` / `TG_NO_PROXY` / `NO_PROXY` to bypass the proxy for specific
-hosts. The bypass list follows standard `NO_PROXY` domain semantics: bare
-domain entries such as `example.com` may match both `example.com` and
-subdomains such as `api.example.com`. It also accepts `*`, suffix entries such
-as `.example.com` or `*.example.com`, IP/CIDR entries such as `127.0.0.0/8`,
-and bracketed IPv6 entries. Host and IP entries may include a port, for example
-`example.com:443` or `[2001:db8::1]:443`; when a port is present, only that
-target port bypasses the proxy.
-
-```bash
-TG_OUTBOUND_PROXY=socks5h://user:pass@192.168.1.1:1080 \
-TG_NO_PROXY=localhost,127.0.0.1,127.0.0.0/8,.lan,example.com:443 \
-tg-ws-proxy
-```
-
-### Cloudflare Proxy
-
-When Telegram's IP ranges are blocked by your ISP, you can route WebSocket
-traffic through Cloudflare using `--cf-domain`.  This requires only a domain
-name — no server-side component.
-
-```bash
-# Use your own Cloudflare-proxied domain
-tg-ws-proxy --cf-domain yourdomain.com
-
-# Multiple domains (tried in order, first has highest priority)
-tg-ws-proxy --cf-domain primary.net,backup.com
-
-# Multiple domains with round-robin load balancing
-tg-ws-proxy --cf-domain primary.net,backup.com --cf-balance
-
-# CF-only mode: omit --dc-ip so CF proxy handles all DCs
-tg-ws-proxy --cf-domain yourdomain.com
-
-# CF priority: try the CF tiers before direct WS, with WS as fallback
-tg-ws-proxy --dc-ip 2:149.154.167.220 --cf-domain yourdomain.com --cf-priority
-
-# Or via environment variable
-TG_CF_DOMAIN=yourdomain.com tg-ws-proxy
-```
-
-The proxy will try the CF path as a fallback after direct WebSocket fails.
-With `--cf-priority`, the Cloudflare tiers — the Worker tunnel first, then the
-CF proxy — are tried **before** direct WebSocket for all DCs.
-
-A `--dc-ip` address whose TCP connect *times out* is stepped over for
-`--ip-fail-cooldown` seconds (default one hour) whenever a fallback tier is
-configured, instead of costing every later connection another connect timeout.
-A refused or redirected connection does not count — only a timeout, which is
-what a DPI-blocked address looks like, and only at the full connect timeout
-(not the short probe a DC in cooldown gets).
-
-Stepped over, not written off: if every fallback tier is also failing, the
-address is re-probed rather than leaving the client on raw TCP for the rest of
-the window, and the first direct connect that succeeds clears the cooldown.
-
-Every connection retries every configured CF domain fresh — a failure isn't
-remembered across connections (matching upstream tg-ws-proxy), so one flaky
-domain can never block the others, or the whole DC, from being tried.
-
-#### `--cf-balance` — round-robin load balancing
-
-When multiple `--cf-domain` values are given, connections normally always start
-with the first domain.  Adding `--cf-balance` distributes connections evenly
-across all configured CF domains using round-robin selection:
-
-```bash
-tg-ws-proxy --cf-domain d1.example.com,d2.example.com,d3.example.com --cf-balance
-# connection 0 → tries d1, then d2, then d3
-# connection 1 → tries d2, then d3, then d1
-# connection 2 → tries d3, then d1, then d2
-```
-
-The remaining domains still serve as ordered fallbacks if the primary one
-fails, so resilience is unchanged.  Has no effect when only one CF domain is
-configured.  Can be combined with `--cf-priority`:
-
-```bash
-# Round-robin CF load balancing, tried before direct WS
-tg-ws-proxy --cf-domain d1.example.com,d2.example.com --cf-balance --cf-priority
-```
-
-**One-time domain setup** (do this in the Cloudflare dashboard):
-
-1. In **SSL/TLS → Overview** set mode to **Flexible**.
-2. In **DNS → Records** add these proxied (`🔶`) A records:
-
-   | Name      | IPv4 address      |
-   |-----------|-------------------|
-   | `kws1`    | `149.154.175.50`  |
-   | `kws1-1`  | `149.154.175.50`  |
-   | `kws2`    | `149.154.167.51`  |
-   | `kws2-1`  | `149.154.167.51`  |
-   | `kws3`    | `149.154.175.100` |
-   | `kws3-1`  | `149.154.175.100` |
-   | `kws4`    | `149.154.167.91`  |
-   | `kws4-1`  | `149.154.167.91`  |
-   | `kws5`    | `149.154.171.5`   |
-   | `kws5-1`  | `149.154.171.5`   |
-   | `kws203`  | `91.105.192.100`  |
-   | `kws203-1`| `91.105.192.100`  |
-
-See [docs/CfProxy.md](docs/CfProxy.md) for full instructions.
-
-### Cloudflare Worker
-
-Cloudflare Worker mode is an alternative to `--cf-domain` when you do not own
-a domain. Deploy the Worker script from [docs/CfWorker.md](docs/CfWorker.md),
-copy its `*.workers.dev` domain, and pass it to the proxy:
-
-```bash
-tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev
-```
-
-Multiple Worker domains are supported (comma-separated or repeated flag).
-With `--cf-balance`, each new connection starts from a different Worker and
-falls back to the remaining Workers if the first one fails.
-
-```bash
-tg-ws-proxy --cf-worker-domain w1.user.workers.dev,w2.user.workers.dev --cf-balance
-```
-
-Or via environment variable:
-
-```bash
-TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev tg-ws-proxy
-```
-
-The Worker accepts an outer WebSocket connection from `tg-ws-proxy-rs`, opens a
-raw TCP connection to the selected Telegram DC IP, and forwards WebSocket
-message payloads as TCP bytes:
-
-```
-tg-ws-proxy-rs → wss://<worker>/apiws?dst=<dc-ip>&dc=<dc>&media=<0|1>
-Cloudflare Worker → TCP <dc-ip>:443
-```
-
-For DCs with a configured direct WebSocket target, direct WS is tried first and
-the Worker is used only after that path fails. For DCs without a direct WS
-target, the Worker is tried before the regular Cloudflare proxy/default
-domains and the remaining fallbacks.
-
-### Domain fronting
-
-If direct WebSocket connections to Telegram keep timing out — a common sign
-of SNI-based DPI blocking — the proxy can fall back to **domain fronting**:
-presenting an unrelated, presumably-unblocked domain as the TLS SNI while
-still connecting to the real Telegram DC IP and using the real DC domain as
-the HTTP `Host`. DPI that filters by SNI sees the fronted name; the actual
-(TLS-encrypted) request still reaches Telegram normally.
-
-```bash
-tg-ws-proxy --dc-ip 2:149.154.167.220 --fronting-domain sprinthost.ru
-```
-
-**Only takes effect when `--dc-ip` is configured for a DC** — this matches
-upstream tg-ws-proxy exactly: fronting is purely a direct-connection
-technique and is never applied to CF proxy, CF Worker, or upstream MTProto
-proxy connections (see their respective sections below). If you rely solely
-on `--cf-domain`/`--default-domains` — the common way to route around a
-block, and what suppresses the built-in `--dc-ip` default (see the
-`--dc-ip` row above) — `--fronting-domain` has no effect, by design.
-Upstream's own guidance for a network that blocks Telegram's IPs outright
-(where fronting can't help either, since it still needs a real TCP
-connection to that IP) is to leave `--dc-ip` unset entirely.
-
-Disabled unless `--fronting-domain` is set. Once a fronted connection
-succeeds, the fallback stays active (including for background connection-pool
-refills) for `--fronting-cooldown` seconds (default 1800 = 30 min), so the
-proxy doesn't keep re-probing the likely-still-blocked direct path on every
-new connection. If a fronting attempt fails, `--fronting-fail-cooldown`
-seconds (default 60) pass before it's retried for that DC — otherwise a
-network where fronting can never succeed (e.g. the DC IP itself is blocked)
-would pay for a doomed attempt on every single connection.
-
-> **Note:** TLS certificate verification is unconditionally skipped on
-> connections using this fallback, regardless of
-> `--danger-accept-invalid-certs` — the real Telegram certificate can never
-> match a fronted SNI, so hostname verification would always fail. This is
-> inherent to the technique, not a bug, and only applies to the direct-WS
-> fallback path (not CF proxy/Worker connections).
-
-### Default domains
-
-Don't want to configure your own Cloudflare DNS zone?  Use `--default-domains`
-to automatically fetch a pre-configured, working list of CF proxy domains from
-the upstream repository:
-
-```bash
-# No Cloudflare account or DNS setup required
-tg-ws-proxy --default-domains
-
-# Enable CF priority so CF path is tried first
-tg-ws-proxy --default-domains --cf-priority
-
-# Combine with your own domain (yours gets highest priority)
-tg-ws-proxy --cf-domain yourdomain.com --default-domains
-
-# Test the fetched domains before starting the proxy
-tg-ws-proxy --default-domains --check
-```
-
-Or via environment variable:
-
-```bash
-TG_DEFAULT_DOMAINS=true tg-ws-proxy
-```
-
-At startup the proxy fetches an obfuscated domain list from
-[Flowseal/tg-ws-proxy](https://github.com/Flowseal/tg-ws-proxy/blob/main/.github/cfproxy-domains.txt),
-deobfuscates it, and appends the decoded domains after any explicit
-`--cf-domain` entries.  If the fetch fails (network not yet available,
-GitHub unreachable) the proxy falls back to a small built-in list and logs a
-warning — it will still start normally.
-
-> **Note:** These are community-maintained domains; availability may change
-> over time.  For maximum reliability, consider setting up your own
-> Cloudflare zone (see [docs/CfProxy.md](docs/CfProxy.md)).
-
-### Router deployment
-
-Run the proxy on your router without `--host` (or with `--host 0.0.0.0`) so
-it accepts connections from all LAN devices:
-
-```bash
-tg-ws-proxy --port 1443
-```
-
-When no `--host` is given and a LAN IP can be auto-detected, the proxy binds
-`0.0.0.0` (all interfaces) and uses the detected LAN IP in the generated
-`tg://` link, so the link is actually reachable and you can share it with
-every device on your network.
-
-If auto-detection picks the wrong interface, override it explicitly:
-
-```bash
-tg-ws-proxy --host 0.0.0.0 --link-ip 192.168.1.1
-```
-
-> **Note:** Passing `--host 127.0.0.1` explicitly restricts connections to the
-> machine running the proxy. Other devices on the network will not be able to
-> connect unless you use `0.0.0.0` (or omit `--host` entirely) so it binds to
-> the router's LAN IP.
-
-## Telegram Desktop Setup
-
-1. **Settings → Advanced → Connection type → Use custom proxy**
-2. Add MTProto proxy:
-   - **Server:** `127.0.0.1`
-   - **Port:** `1443` (or your `--port`)
-   - **Secret:** shown in the proxy startup log
-
-Or use the `tg://proxy?...` link that is printed on startup.
-
-## Cross-compilation for OpenWrt
-
-OpenWrt uses musl libc and runs on MIPS, ARM, and ARM64 CPUs.  Building a
-fully static Rust binary requires:
-
-1. A C cross-compiler for your target (used by `ring`/`aws-lc-sys`)
-2. The matching Rust target
-
-### ARM64 (aarch64) — e.g. GL.iNet MT6000, Banana Pi R4
-
-```bash
-# Install the cross toolchain (Ubuntu/Debian)
-apt-get install gcc-aarch64-linux-gnu
-
-# Add the Rust target
-rustup target add aarch64-unknown-linux-musl
-
-# Uncomment the [target.aarch64-unknown-linux-musl] section in .cargo/config.toml,
-# then build:
-cargo build --release --target aarch64-unknown-linux-musl
-```
-
-### ARM (armv7) — e.g. older GL.iNet routers, some TP-Link models
-
-```bash
-apt-get install gcc-arm-linux-gnueabihf
-rustup target add armv7-unknown-linux-musleabihf
-# Uncomment the armv7 section in .cargo/config.toml
-cargo build --release --target armv7-unknown-linux-musleabihf
-```
-
-### MIPS LE — e.g. TP-Link WR series
-
-```bash
-apt-get install gcc-mipsel-linux-gnu
-rustup target add mipsel-unknown-linux-musl
-# Uncomment the mipsel section in .cargo/config.toml
-cargo build --release --target mipsel-unknown-linux-musl
-```
-
-### Using `cross` (easier alternative)
-
-[`cross`](https://github.com/cross-rs/cross) uses Docker to manage toolchains:
-
-```bash
-cargo install cross
-cross build --release --target aarch64-unknown-linux-musl
-```
-
-### OpenWrt procd init script
-
-Create `/etc/init.d/tg-ws-proxy`:
-
-```sh
-#!/bin/sh /etc/rc.common
-USE_PROCD=1
-START=90
-STOP=10
-
-PROG=/usr/local/bin/tg-ws-proxy
-
-start_service() {
-    procd_open_instance
-    procd_set_param command "$PROG" --host 0.0.0.0 --port 1443
-    procd_set_param respawn
-    procd_set_param stdout 1
-    procd_set_param stderr 1
-    procd_close_instance
-}
-```
-
-```bash
-chmod +x /etc/init.d/tg-ws-proxy
-/etc/init.d/tg-ws-proxy enable
-/etc/init.d/tg-ws-proxy start
 ```
 
 ## How it works
@@ -648,77 +173,25 @@ chmod +x /etc/init.d/tg-ws-proxy
    IP).
 4. The relay init packet is sent to Telegram, and bidirectional bridging
    begins with AES-256-CTR re-encryption (client keys ↔ relay keys).
-5. If WebSocket is unavailable and Cloudflare Worker is configured, the proxy can open
-   `wss://<worker>/apiws?dst=<dc-ip>` and tunnel raw TCP traffic to the DC via
-   the Worker.
-6. If Worker is unavailable or not configured, the proxy tries the Cloudflare
-   proxy path (`wss://kwsN.{cf-domain}/apiws`) if `--cf-domain` is configured.
-7. If CF paths are unavailable or not configured, each upstream MTProto proxy
-   is tried in order (generating a fresh client handshake with the upstream's
-   secret so it can route to the correct DC).
-8. If no upstream proxy is configured or all fail, the proxy falls back to
-   direct TCP on port 443.
-9. A small pool of pre-connected WebSocket connections is maintained per DC to
+5. If that path fails, each configured fallback tier is tried in turn —
+   Cloudflare Worker, Cloudflare proxy, upstream MTProto proxy, then direct
+   TCP on port 443.
+6. A small pool of pre-connected WebSocket connections is maintained per DC to
    reduce connection latency for subsequent clients.
 
-## Project structure
+The tier order, how to configure each one, and when a failing tier goes into
+cooldown are all documented in [docs/Fallbacks.md](docs/Fallbacks.md).
 
-```
-src/
-  main.rs              — Entry point, CLI parsing, server startup, banner
-  config.rs            — ProxyConfig struct, argument parsing, env-var aliases
-  crypto.rs            — MTProto obfuscation: handshake parsing, relay init generation,
-                         AES-256-CTR key derivation and cipher construction
-  splitter.rs          — MTProto packet splitter for correct WebSocket framing
-  ws_client.rs         — WebSocket client for Telegram DC connections (IP routing + SNI)
-  pool.rs              — Pre-warmed WebSocket connection pool per DC
-  proxy.rs             — Client handler, re-encryption bridge, TCP fallback logic
-  default_domains.rs   — Fetches and deobfuscates the default CF proxy domain list
-docs/
-  CfProxy.md           — Cloudflare DNS proxy setup
-  CfWorker.md          — Cloudflare Worker TCP tunnel setup
-.cargo/
-  config.toml          — Cross-compilation target presets (commented out)
-```
+## Documentation
 
-## Configuration via environment
-
-```bash
-TG_HOST=0.0.0.0
-TG_PORT=1443
-TG_SECRET=0123456789abcdef0123456789abcdef
-TG_POOL_SIZE=4
-TG_BUF_KB=256
-TG_MAX_CONNECTIONS=64
-TG_QUIET=true
-TG_VERBOSE=false
-TG_CF_DOMAIN=yourdomain.com
-TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev
-TG_CF_PRIORITY=false
-TG_CF_BALANCE=false
-TG_DEFAULT_DOMAINS=false
-TG_OUTBOUND_PROXY=socks5h://user:pass@192.168.1.1:1080
-TG_NO_OUTBOUND_PROXY=false
-TG_NO_PROXY=localhost,127.0.0.1
-TG_LOG_FILE=/var/log/tg-ws-proxy.log
-TG_MTPROTO_PROXY=proxy.example.com:443:ddabcdef1234567890abcdef1234567890
-```
-
-## Windows console — no garbled characters
-
-On Windows the console does not enable ANSI/VT colour codes by default, which
-caused log lines to show symbols like `←[32m` around the log level.  This is
-fixed: ANSI escape codes are automatically disabled when running on Windows or
-when stderr is not a terminal (e.g. output is piped or redirected).
-
-If you prefer completely clean logs or want to capture them to a file, use
-`--log-file`:
-
-```bash
-tg-ws-proxy --log-file proxy.log
-# or
-set TG_LOG_FILE=proxy.log && tg-ws-proxy
-```
+| Guide | Covers |
+|---|---|
+| [docs/Fallbacks.md](docs/Fallbacks.md) | Routing tiers: Cloudflare proxy/Worker, default domains, domain fronting, upstream MTProto proxies, inbound FakeTLS, outbound proxy |
+| [docs/Building.md](docs/Building.md) | Building, cross-compiling for OpenWrt, and shrinking the binary with UPX |
+| [docs/Deployment.md](docs/Deployment.md) | Docker, router deployment, OpenWrt init script, environment variables |
+| [docs/CfProxy.md](docs/CfProxy.md) | Cloudflare DNS proxy setup, step by step |
+| [docs/CfWorker.md](docs/CfWorker.md) | Cloudflare Worker TCP tunnel setup |
+| [AGENTS.md](AGENTS.md) | Repository layout and conventions for contributors |
 
 ## License
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,0 +1,177 @@
+# Building
+
+Pre-built binaries for every supported target are on the
+[Releases](../../releases) page — this guide is for building your own.
+
+## From source
+
+```bash
+# Debug build
+cargo build
+
+# Optimised release build
+cargo build --release
+
+# Static binary for Linux x86_64 (e.g. for Docker scratch images)
+rustup target add x86_64-unknown-linux-musl
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+The binary lands in `target/release/tg-ws-proxy`, or
+`target/<target>/release/tg-ws-proxy` when cross-compiling.
+
+## Cross-platform builds with `cargo-zigbuild`
+
+[`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) uses the Zig
+compiler as a drop-in C cross-linker, so you can build for every platform from
+a single Linux or macOS host without installing any platform SDKs.
+
+```bash
+# Install cargo-zigbuild and Zig
+pip install ziglang        # or: brew install zig
+cargo install cargo-zigbuild
+
+# Add all required Rust targets in one shot
+rustup target add \
+  x86_64-unknown-linux-musl \
+  aarch64-unknown-linux-musl \
+  armv7-unknown-linux-musleabihf \
+  mipsel-unknown-linux-musl \
+  x86_64-apple-darwin \
+  aarch64-apple-darwin \
+  x86_64-pc-windows-gnu
+
+# Build for all platforms
+cargo zigbuild --release --target x86_64-unknown-linux-musl       # Linux x86-64 (musl static)
+cargo zigbuild --release --target aarch64-unknown-linux-musl      # Linux / OpenWrt ARM64
+cargo zigbuild --release --target armv7-unknown-linux-musleabihf  # OpenWrt ARMv7
+cargo zigbuild --release --target mipsel-unknown-linux-musl       # OpenWrt MIPS LE
+cargo zigbuild --release --target x86_64-apple-darwin             # macOS Intel
+cargo zigbuild --release --target aarch64-apple-darwin            # macOS Apple Silicon
+cargo zigbuild --release --target x86_64-pc-windows-gnu           # Windows x86-64
+```
+
+> **Note:** Building macOS targets (`*-apple-darwin`) requires the macOS SDK
+> (XCode Command Line Tools). On Linux you can use
+> [`osxcross`](https://github.com/tpoechtrager/osxcross) to supply the SDK
+> and then set `SDKROOT` / `MACOSX_DEPLOYMENT_TARGET` appropriately before
+> running `cargo zigbuild`.
+
+## Cross-compilation for OpenWrt
+
+OpenWrt uses musl libc and runs on MIPS, ARM, and ARM64 CPUs. A fully static
+Rust binary needs two things:
+
+1. A C cross-compiler for your target (used by `ring`/`aws-lc-sys`)
+2. The matching Rust target
+
+`.cargo/config.toml` ships a commented-out `[target.*]` block per platform —
+uncomment the one you need before building.
+
+### ARM64 (aarch64) — e.g. GL.iNet MT6000, Banana Pi R4
+
+```bash
+apt-get install gcc-aarch64-linux-gnu
+rustup target add aarch64-unknown-linux-musl
+# Uncomment the aarch64 section in .cargo/config.toml
+cargo build --release --target aarch64-unknown-linux-musl
+```
+
+### ARM (armv7) — e.g. older GL.iNet routers, some TP-Link models
+
+```bash
+apt-get install gcc-arm-linux-gnueabihf
+rustup target add armv7-unknown-linux-musleabihf
+# Uncomment the armv7 section in .cargo/config.toml
+cargo build --release --target armv7-unknown-linux-musleabihf
+```
+
+### MIPS LE — e.g. TP-Link WR series
+
+```bash
+apt-get install gcc-mipsel-linux-gnu
+rustup target add mipsel-unknown-linux-musl
+# Uncomment the mipsel section in .cargo/config.toml
+cargo build --release --target mipsel-unknown-linux-musl
+```
+
+MIPS targets are tier-3 in Rust and have no pre-built `std`, so release CI
+builds them on nightly with `-Z build-std=std,panic_abort` under
+[`cross`](https://github.com/cross-rs/cross). Do the same locally if a plain
+`cargo build` complains about a missing `std` for the target.
+
+### Using `cross` (easier alternative)
+
+[`cross`](https://github.com/cross-rs/cross) uses Docker to manage toolchains,
+so you don't need any host cross-compiler:
+
+```bash
+cargo install cross
+cross build --release --target aarch64-unknown-linux-musl
+```
+
+## Shrinking the binary for flash-constrained devices
+
+A release build is around 4.8 MB, which is a lot on a router with 8 or 16 MB of
+flash. The releases page carries a `-upx` variant of every Linux musl asset
+(`tg-ws-proxy-<target>-upx.tar.gz`) for exactly this case — on mipsel that is
+**4.85 MB → 1.43 MB**, a 70% cut.
+
+To pack a binary you built yourself:
+
+```bash
+upx -9 --lzma target/mipsel-unknown-linux-musl/release/tg-ws-proxy
+upx -t      target/mipsel-unknown-linux-musl/release/tg-ws-proxy   # verify
+```
+
+### The trade-off
+
+UPX buys flash with RAM. A normal ELF maps its code straight from the file, so
+only the pages actually touched are resident and the kernel can evict them
+under pressure and re-read them later. The UPX stub instead decompresses the
+entire image into anonymous memory at startup — nothing is file-backed, and a
+router has no swap to page it out to, so it stays resident for the life of the
+process.
+
+| | Plain build | UPX `-9 --lzma` |
+|---|---|---|
+| Flash | ~4.8 MB | ~1.4 MB |
+| RSS | ~3–5 MB (working set, evictable) | roughly +4 MB on top, permanently resident |
+| Startup | instant | one LZMA decompression, ~1 s on a slow MIPS CPU |
+| Throughput | unchanged | unchanged |
+
+So it is a good trade on a device with plenty of RAM and little flash, and a
+bad one on a 32 MB-RAM device — which is why the packed builds ship as separate
+assets rather than replacing the normal ones.
+
+If the startup delay bothers you more than the last few hundred KB, drop
+`--lzma`: plain `-9` decompresses several times faster for about 5–8% more
+size.
+
+**Not for Windows or macOS.** UPX-packed PE files trip antivirus heuristics,
+which is a real problem for a tool of this kind, and packing a Mach-O
+invalidates its code signature — arm64 macOS then refuses to run it at all.
+
+### Why not `opt-level = "z"`?
+
+Optimising for size is the obvious alternative, and it does shrink the binary
+by roughly a third. But it costs throughput on exactly the machines that need
+the flash: every relayed byte is decrypted with the client's key and
+re-encrypted with the DC's key, and MIPS/ARMv7 have no AES instructions, so
+that runs on the `aes` crate's software backend.
+
+Measured on that software backend (`--cfg aes_force_soft`, the same code path a
+router executes):
+
+| Profile | AES-256-CTR relay throughput | Binary size |
+|---|---|---|
+| `opt-level = 3` (shipped) | ~135 MiB/s | baseline |
+| `opt-level = "z"` | ~103 MiB/s | −34% |
+
+A quarter of the proxy's throughput for a third of the size is a worse deal
+than UPX's, which gives 70% for no steady-state cost at all. The release
+profile therefore stays at `opt-level = 3`, and `panic = "abort"` is left off
+for a similar reason: it would save about 18%, but today a panic while parsing
+a malformed connection is caught by the tokio runtime and kills only that
+connection, whereas with `abort` it would take down the proxy for every
+connected user.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,0 +1,142 @@
+# Deployment
+
+## Docker
+
+Images are published to Docker Hub as
+[`valnesfjord/tg-ws-proxy-rs`](https://hub.docker.com/r/valnesfjord/tg-ws-proxy-rs)
+for `linux/amd64` and `linux/arm64`. Tags follow the releases: `latest`, plus
+`X.Y.Z` and `X.Y` per version.
+
+```bash
+docker run -d --name tg-ws-proxy -p 1443:1443 valnesfjord/tg-ws-proxy-rs
+```
+
+The image is built `FROM scratch` and runs as UID 1000 — it contains the static
+binary and a CA bundle, nothing else. Flags go after the image name, and every
+flag also has a `TG_*` environment variable:
+
+```bash
+docker run -d --name tg-ws-proxy -p 1443:1443 \
+  -e TG_SECRET=0123456789abcdef0123456789abcdef \
+  -e TG_DEFAULT_DOMAINS=true \
+  valnesfjord/tg-ws-proxy-rs --link-ip 203.0.113.10
+```
+
+Two things worth setting explicitly in a container:
+
+- **`TG_SECRET`** — without it a fresh random secret is generated on every
+  start, so the `tg://` link changes each time the container restarts.
+- **`--link-ip`** — host auto-detection sees the container's bridge address
+  (something like `172.17.0.2`), which nobody can reach. Pass the address
+  clients should actually connect to. Using `--network host` avoids this
+  instead.
+
+## Router deployment
+
+Run the proxy on your router without `--host` (or with `--host 0.0.0.0`) so it
+accepts connections from all LAN devices:
+
+```bash
+tg-ws-proxy --port 1443
+```
+
+When no `--host` is given and a LAN IP can be auto-detected, the proxy binds
+`0.0.0.0` (all interfaces) and uses the detected LAN IP in the generated
+`tg://` link, so the link is actually reachable and you can share it with every
+device on your network.
+
+If auto-detection picks the wrong interface, override it explicitly:
+
+```bash
+tg-ws-proxy --host 0.0.0.0 --link-ip 192.168.1.1
+```
+
+> **Note:** Passing `--host 127.0.0.1` explicitly restricts connections to the
+> machine running the proxy. Other devices on the network will not be able to
+> connect unless you use `0.0.0.0` (or omit `--host` entirely) so it binds to
+> the router's LAN IP.
+
+On flash-tight routers, grab the `-upx` release asset — it is about 70% smaller
+on disk. See [Building.md](Building.md#shrinking-the-binary-for-flash-constrained-devices)
+for what that costs in RAM.
+
+### OpenWrt procd init script
+
+Create `/etc/init.d/tg-ws-proxy`:
+
+```sh
+#!/bin/sh /etc/rc.common
+USE_PROCD=1
+START=90
+STOP=10
+
+PROG=/usr/local/bin/tg-ws-proxy
+
+start_service() {
+    procd_open_instance
+    procd_set_param command "$PROG" --host 0.0.0.0 --port 1443
+    procd_set_param respawn
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}
+```
+
+```bash
+chmod +x /etc/init.d/tg-ws-proxy
+/etc/init.d/tg-ws-proxy enable
+/etc/init.d/tg-ws-proxy start
+```
+
+## Configuration via environment
+
+Every CLI flag has a matching `TG_*` variable, which is usually the easier way
+to configure Docker and systemd units:
+
+```bash
+TG_HOST=0.0.0.0
+TG_PORT=1443
+TG_SECRET=0123456789abcdef0123456789abcdef
+TG_LINK_IP=192.168.1.1
+TG_LISTEN_FAKETLS_DOMAIN=www.yandex.ru
+TG_POOL_SIZE=4
+TG_BUF_KB=256
+TG_MAX_CONNECTIONS=64
+TG_QUIET=true
+TG_VERBOSE=false
+TG_SKIP_TLS_VERIFY=false
+TG_CF_DOMAIN=yourdomain.com
+TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev
+TG_CF_PRIORITY=false
+TG_CF_BALANCE=false
+TG_DEFAULT_DOMAINS=false
+TG_CHECK=false
+TG_FRONTING_DOMAIN=sprinthost.ru
+TG_FRONTING_COOLDOWN=1800
+TG_FRONTING_FAIL_COOLDOWN=60
+TG_OUTBOUND_PROXY=socks5h://user:pass@192.168.1.1:1080
+TG_NO_OUTBOUND_PROXY=false
+TG_NO_PROXY=localhost,127.0.0.1
+TG_LOG_FILE=/var/log/tg-ws-proxy.log
+TG_MTPROTO_PROXY=proxy.example.com:443:ddabcdef1234567890abcdef1234567890
+```
+
+When `TG_OUTBOUND_PROXY` is not set, the standard `HTTPS_PROXY`, `ALL_PROXY`,
+`HTTP_PROXY` and `NO_PROXY` variables are honored as well — see
+[Fallbacks.md](Fallbacks.md#outbound-proxy).
+
+## Windows console — no garbled characters
+
+On Windows the console does not enable ANSI/VT colour codes by default, which
+caused log lines to show symbols like `←[32m` around the log level. This is
+fixed: ANSI escape codes are automatically disabled when running on Windows or
+when stderr is not a terminal (e.g. output is piped or redirected).
+
+If you prefer completely clean logs or want to capture them to a file, use
+`--log-file`:
+
+```bash
+tg-ws-proxy --log-file proxy.log
+# or
+set TG_LOG_FILE=proxy.log && tg-ws-proxy
+```

--- a/docs/Fallbacks.md
+++ b/docs/Fallbacks.md
@@ -1,0 +1,320 @@
+# Routing and fallbacks
+
+Every client connection is routed through the first tier that works. Tiers that
+are not configured are skipped entirely.
+
+```
+direct WS to the DC              ← default
+  ↓ Cloudflare Worker            ← --cf-worker-domain
+  ↓ Cloudflare proxy             ← --cf-domain / --default-domains
+  ↓ upstream MTProto proxy       ← --mtproto-proxy
+  ↓ direct TCP :443              ← last resort
+```
+
+`--cf-priority` flips the first two groups: the Cloudflare tiers (Worker first,
+then CF proxy) are tried **before** direct WebSocket for all DCs. Domain
+fronting is a modifier on the direct-WS tier rather than a tier of its own.
+
+A small pool of pre-connected WebSocket connections is kept per DC
+(`--pool-size`) so later clients skip the handshake latency.
+
+## Cloudflare Proxy
+
+When Telegram's IP ranges are blocked by your ISP, you can route WebSocket
+traffic through Cloudflare using `--cf-domain`. This requires only a domain
+name — no server-side component.
+
+```bash
+# Use your own Cloudflare-proxied domain
+tg-ws-proxy --cf-domain yourdomain.com
+
+# Multiple domains (tried in order, first has highest priority)
+tg-ws-proxy --cf-domain primary.net,backup.com
+
+# Multiple domains with round-robin load balancing
+tg-ws-proxy --cf-domain primary.net,backup.com --cf-balance
+
+# CF-only mode: omit --dc-ip so CF proxy handles all DCs
+tg-ws-proxy --cf-domain yourdomain.com
+
+# CF priority: try the CF tiers before direct WS, with WS as fallback
+tg-ws-proxy --dc-ip 2:149.154.167.220 --cf-domain yourdomain.com --cf-priority
+
+# Or via environment variable
+TG_CF_DOMAIN=yourdomain.com tg-ws-proxy
+```
+
+A `--dc-ip` address whose TCP connect *times out* is stepped over for
+`--ip-fail-cooldown` seconds (default one hour) whenever a fallback tier is
+configured, instead of costing every later connection another connect timeout.
+A refused or redirected connection does not count — only a timeout, which is
+what a DPI-blocked address looks like, and only at the full connect timeout
+(not the short probe a DC in cooldown gets).
+
+Stepped over, not written off: if every fallback tier is also failing, the
+address is re-probed rather than leaving the client on raw TCP for the rest of
+the window, and the first direct connect that succeeds clears the cooldown.
+
+Every connection retries every configured CF domain fresh — a failure isn't
+remembered across connections (matching upstream tg-ws-proxy), so one flaky
+domain can never block the others, or the whole DC, from being tried.
+
+### `--cf-balance` — round-robin load balancing
+
+When multiple `--cf-domain` values are given, connections normally always start
+with the first domain. Adding `--cf-balance` distributes connections evenly
+across all configured CF domains using round-robin selection:
+
+```bash
+tg-ws-proxy --cf-domain d1.example.com,d2.example.com,d3.example.com --cf-balance
+# connection 0 → tries d1, then d2, then d3
+# connection 1 → tries d2, then d3, then d1
+# connection 2 → tries d3, then d1, then d2
+```
+
+The remaining domains still serve as ordered fallbacks if the primary one
+fails, so resilience is unchanged. Has no effect when only one CF domain is
+configured. Can be combined with `--cf-priority`:
+
+```bash
+# Round-robin CF load balancing, tried before direct WS
+tg-ws-proxy --cf-domain d1.example.com,d2.example.com --cf-balance --cf-priority
+```
+
+### One-time domain setup
+
+Do this in the Cloudflare dashboard:
+
+1. In **SSL/TLS → Overview** set mode to **Flexible**.
+2. In **DNS → Records** add these proxied (`🔶`) A records:
+
+   | Name      | IPv4 address      |
+   |-----------|-------------------|
+   | `kws1`    | `149.154.175.50`  |
+   | `kws1-1`  | `149.154.175.50`  |
+   | `kws2`    | `149.154.167.51`  |
+   | `kws2-1`  | `149.154.167.51`  |
+   | `kws3`    | `149.154.175.100` |
+   | `kws3-1`  | `149.154.175.100` |
+   | `kws4`    | `149.154.167.91`  |
+   | `kws4-1`  | `149.154.167.91`  |
+   | `kws5`    | `149.154.171.5`   |
+   | `kws5-1`  | `149.154.171.5`   |
+   | `kws203`  | `91.105.192.100`  |
+   | `kws203-1`| `91.105.192.100`  |
+
+See [CfProxy.md](CfProxy.md) for full instructions.
+
+## Cloudflare Worker
+
+Cloudflare Worker mode is an alternative to `--cf-domain` when you do not own a
+domain. Deploy the Worker script from [CfWorker.md](CfWorker.md), copy its
+`*.workers.dev` domain, and pass it to the proxy:
+
+```bash
+tg-ws-proxy --cf-worker-domain random-symbols-1234.username.workers.dev
+```
+
+Multiple Worker domains are supported (comma-separated or repeated flag).
+With `--cf-balance`, each new connection starts from a different Worker and
+falls back to the remaining Workers if the first one fails.
+
+```bash
+tg-ws-proxy --cf-worker-domain w1.user.workers.dev,w2.user.workers.dev --cf-balance
+```
+
+Or via environment variable:
+
+```bash
+TG_CF_WORKER_DOMAIN=random-symbols-1234.username.workers.dev tg-ws-proxy
+```
+
+The Worker accepts an outer WebSocket connection from `tg-ws-proxy-rs`, opens a
+raw TCP connection to the selected Telegram DC IP, and forwards WebSocket
+message payloads as TCP bytes:
+
+```
+tg-ws-proxy-rs → wss://<worker>/apiws?dst=<dc-ip>&dc=<dc>&media=<0|1>
+Cloudflare Worker → TCP <dc-ip>:443
+```
+
+For DCs with a configured direct WebSocket target, direct WS is tried first and
+the Worker is used only after that path fails. For DCs without a direct WS
+target, the Worker is tried before the regular Cloudflare proxy/default domains
+and the remaining fallbacks.
+
+## Default domains
+
+Don't want to configure your own Cloudflare DNS zone? Use `--default-domains`
+to automatically fetch a pre-configured, working list of CF proxy domains from
+the upstream repository:
+
+```bash
+# No Cloudflare account or DNS setup required
+tg-ws-proxy --default-domains
+
+# Enable CF priority so CF path is tried first
+tg-ws-proxy --default-domains --cf-priority
+
+# Combine with your own domain (yours gets highest priority)
+tg-ws-proxy --cf-domain yourdomain.com --default-domains
+
+# Test the fetched domains before starting the proxy
+tg-ws-proxy --default-domains --check
+```
+
+Or via environment variable:
+
+```bash
+TG_DEFAULT_DOMAINS=true tg-ws-proxy
+```
+
+At startup the proxy fetches an obfuscated domain list from
+[Flowseal/tg-ws-proxy](https://github.com/Flowseal/tg-ws-proxy/blob/main/.github/cfproxy-domains.txt),
+deobfuscates it, and appends the decoded domains after any explicit
+`--cf-domain` entries. If the fetch fails (network not yet available, GitHub
+unreachable) the proxy falls back to a small built-in list and logs a warning —
+it will still start normally.
+
+> **Note:** These are community-maintained domains; availability may change
+> over time. For maximum reliability, consider setting up your own Cloudflare
+> zone (see [CfProxy.md](CfProxy.md)).
+
+## Domain fronting
+
+If direct WebSocket connections to Telegram keep timing out — a common sign of
+SNI-based DPI blocking — the proxy can fall back to **domain fronting**:
+presenting an unrelated, presumably-unblocked domain as the TLS SNI while still
+connecting to the real Telegram DC IP and using the real DC domain as the HTTP
+`Host`. DPI that filters by SNI sees the fronted name; the actual
+(TLS-encrypted) request still reaches Telegram normally.
+
+```bash
+tg-ws-proxy --dc-ip 2:149.154.167.220 --fronting-domain sprinthost.ru
+```
+
+**Only takes effect when `--dc-ip` is configured for a DC** — this matches
+upstream tg-ws-proxy exactly: fronting is purely a direct-connection technique
+and is never applied to CF proxy, CF Worker, or upstream MTProto proxy
+connections. If you rely solely on `--cf-domain`/`--default-domains` — the
+common way to route around a block, and what suppresses the built-in `--dc-ip`
+default — `--fronting-domain` has no effect, by design. Upstream's own guidance
+for a network that blocks Telegram's IPs outright (where fronting can't help
+either, since it still needs a real TCP connection to that IP) is to leave
+`--dc-ip` unset entirely.
+
+Disabled unless `--fronting-domain` is set. Once a fronted connection succeeds,
+the fallback stays active (including for background connection-pool refills)
+for `--fronting-cooldown` seconds (default 1800 = 30 min), so the proxy doesn't
+keep re-probing the likely-still-blocked direct path on every new connection. If
+a fronting attempt fails, `--fronting-fail-cooldown` seconds (default 60) pass
+before it's retried for that DC — otherwise a network where fronting can never
+succeed (e.g. the DC IP itself is blocked) would pay for a doomed attempt on
+every single connection.
+
+> **Note:** TLS certificate verification is unconditionally skipped on
+> connections using this fallback, regardless of
+> `--danger-accept-invalid-certs` — the real Telegram certificate can never
+> match a fronted SNI, so hostname verification would always fail. This is
+> inherent to the technique, not a bug, and only applies to the direct-WS
+> fallback path (not CF proxy/Worker connections).
+
+## Upstream MTProto proxy fallback
+
+When WebSocket connections to Telegram are blocked, the proxy can route traffic
+through an external MTProto proxy before falling back to direct TCP.
+
+Pass one or more `--mtproto-proxy HOST:PORT:SECRET` flags (or a comma-separated
+list in `TG_MTPROTO_PROXY`). Proxies are tried in the order given; if one fails
+it enters a 60-second cooldown so subsequent connections skip it without delay.
+
+```bash
+# Padded-intermediate proxy (dd prefix)
+tg-ws-proxy --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef1234567890
+
+# FakeTLS proxy (ee prefix — domain-fronting transport)
+tg-ws-proxy --mtproto-proxy proxy.example.com:443:ee<32-hex-key><hex-encoded-hostname>
+
+# Multiple proxies (tried in order until one succeeds)
+tg-ws-proxy \
+  --mtproto-proxy proxy.example.com:443:ddabcdef1234567890abcdef1234567890 \
+  --mtproto-proxy other.example.net:8888:dddeadbeef01234567deadbeef01234567
+
+# Or via environment variable (comma-separated)
+TG_MTPROTO_PROXY="proxy.example.com:443:ddabcdef1234...,other.example.net:8888:dddeadbeef..." tg-ws-proxy
+```
+
+> **ℹ️ Secret format — pass the secret exactly as shown in the `tg://proxy` link**
+>
+> Public MTProto proxies advertise secrets with a 1-byte prefix that tells the
+> proxy which transport mode to use. **Copy the full secret as-is — prefix included:**
+>
+> | Prefix | Meaning | Example |
+> |--------|---------|---------|
+> | `dd` | Padded-intermediate transport | `ddabcdef1234567890abcdef1234567890` |
+> | `ee` | FakeTLS (domain-fronting) transport | `ee` + 32 hex key chars + hex-encoded hostname |
+> | *(none)* | Plain transport (legacy, 32 hex chars) | `abcdef1234567890abcdef1234567890` |
+>
+> In the `tg://proxy?server=...&secret=` link the `secret=` value already
+> contains the correct prefix. Copy everything after `secret=` and pass it
+> directly to `--mtproto-proxy`.
+
+## Inbound FakeTLS listener
+
+This one is about the *client-facing* side rather than a fallback tier. For
+public home servers where DPI blocks raw inbound MTProto, enable inbound
+FakeTLS:
+
+```bash
+tg-ws-proxy --host 0.0.0.0 --port 443 --listen-faketls-domain www.yandex.ru
+```
+
+This changes only the client-facing transport:
+
+```
+Telegram client → ee FakeTLS → tg-ws-proxy-rs → WSS/TLS → kws*.web.telegram.org
+```
+
+The proxy accepts the TLS ClientHello, validates the FakeTLS HMAC, sends a
+synthetic TLS ServerHello, unwraps TLS Application Data records, and then passes
+the recovered MTProto init into the existing WebSocket backend path.
+
+## Outbound proxy
+
+If the host running tg-ws-proxy-rs can reach the internet only through another
+proxy, route all outgoing connections through `--outbound-proxy`:
+
+```bash
+tg-ws-proxy --outbound-proxy http://user:pass@192.168.1.1:3128
+tg-ws-proxy --outbound-proxy socks5://user:pass@192.168.1.1:1080
+tg-ws-proxy --outbound-proxy socks5h://user:pass@192.168.1.1:1080
+```
+
+`socks5://` resolves hostnames locally before sending the CONNECT request.
+`socks5h://` sends the hostname to the SOCKS proxy and lets it resolve DNS
+remotely. The setting applies to direct Telegram WS, Cloudflare proxy,
+Cloudflare Worker, upstream MTProto proxies, direct TCP fallback, `--check`,
+and the `--default-domains` fetch.
+
+The same setting can be supplied through `TG_OUTBOUND_PROXY`. If it is not set,
+standard `HTTPS_PROXY`, `ALL_PROXY`, `HTTP_PROXY` variables are used in that
+order. `https://` proxy URLs from those standard environment variables are
+ignored when a later supported fallback exists; an explicit
+`--outbound-proxy https://...` remains an error.
+
+Use `TG_OUTBOUND_PROXY=direct` (also accepts `none` or `off`) or
+`--no-outbound-proxy` to disable environment proxy discovery explicitly. Use
+`--no-proxy` / `TG_NO_PROXY` / `NO_PROXY` to bypass the proxy for specific
+hosts. The bypass list follows standard `NO_PROXY` domain semantics: bare domain
+entries such as `example.com` may match both `example.com` and subdomains such
+as `api.example.com`. It also accepts `*`, suffix entries such as
+`.example.com` or `*.example.com`, IP/CIDR entries such as `127.0.0.0/8`, and
+bracketed IPv6 entries. Host and IP entries may include a port, for example
+`example.com:443` or `[2001:db8::1]:443`; when a port is present, only that
+target port bypasses the proxy.
+
+```bash
+TG_OUTBOUND_PROXY=socks5h://user:pass@192.168.1.1:1080 \
+TG_NO_PROXY=localhost,127.0.0.1,127.0.0.0/8,.lan,example.com:443 \
+tg-ws-proxy
+```


### PR DESCRIPTION
Closes #98.

Релиз теперь дополнительно выкладывает UPX-сжатые ассеты `tg-ws-proxy-<target>-upx.tar.gz` для пяти linux-musl целей: mipsel, mips, armv7, aarch64, x86_64. На mipsel это **4.85 → 1.43 МБ** (цифра из issue).

## Почему отдельными ассетами, а не заменой

UPX меняет флеш на ОЗУ. Обычный ELF мапит секцию кода из файла: резидентен только рабочий набор, и под давлением памяти страницы вытесняются и перечитываются с флеша. Стаб UPX вместо этого распаковывает весь образ в анонимную память — файлового бэкинга нет, свопа на роутере нет, и это остаётся резидентным на всё время жизни процесса.

| | Обычная сборка | UPX `-9 --lzma` |
|---|---|---|
| Флеш | ~4.8 МБ | ~1.4 МБ |
| RSS | ~3–5 МБ (рабочий набор, вытесняемый) | сверху ещё ~4 МБ, невытесняемых |
| Старт | мгновенно | одна LZMA-распаковка, ~1 с на медленном MIPS |
| Пропускная способность | — | без изменений |

Хорошая сделка на устройстве с 128 МБ ОЗУ и 8 МБ флеша, плохая — на 32 МБ ОЗУ. Выбор за тем, кто прошивает, поэтому обычные ассеты остаются на месте.

Отдельно замечу: `.tar.gz` и так сжат, так что размер *скачивания* почти не меняется. Выигрыш — в размере распакованного файла **на флеше**, а issue именно про это.

## Почему не `opt-level = "z"`

Автор issue пишет, что собирает с `-z` ради флеша. Это стоит скорости на тех самых машинах, которым нужен маленький бинарь: каждый релеимый байт расшифровывается ключом клиента и перешифровывается ключом датацентра (`proxy.rs`), а у MIPS/ARMv7 нет аппаратного AES — работает софтовый backend крейта `aes`.

Замер на этом backend'е (`--cfg aes_force_soft`, тот же код, что исполняется на роутере):

| Профиль | AES-256-CTR | Размер |
|---|---|---|
| `opt-level = 3` (текущий) | ~135 MiB/s | база |
| `opt-level = "z"` | ~103 MiB/s | −34% |

Четверть пропускной способности за треть размера — сделка хуже, чем у UPX, который даёт 70% вообще без затрат в установившемся режиме. Профиль остаётся на `opt-level = 3`; `panic = "abort"` тоже не берём — он сэкономил бы ~18%, но сейчас паника при разборе кривого соединения ловится рантаймом tokio и убивает только это соединение, а с `abort` положила бы прокси всем подключённым. Всё это записано в `docs/Building.md`, чтобы через полгода никто не «оптимизировал» обратно.

## Как это проверяется в CI

Новая job `compress-assets` работает пост-обработкой: скачивает уже опубликованный тарбол, пакует, заливает — логику сборки дублировать не пришлось.

Битый упакованный бинарь на роутере хуже большого, поэтому проверка в три шага:

1. прогон **исходного** бинаря под `qemu-<arch>-static` — если падает здесь, проблема в эмуляторе, а не в UPX, и проверка ниже ничего бы не значила;
2. `upx -t`;
3. реальный запуск **упакованного** под qemu. `upx -t` доказывает только, что payload распаковывается обратно; до пользователей же доезжает другой отказ — стаб спаковался чисто и умер на целевом ABI.

UPX 5.2.0 качается с пином версии и проверкой sha256, без сторонних экшенов. `if: !cancelled()` — потому что `upload-assets` покрывает ещё Windows и macOS, и сбой там не должен молча уносить все `-upx` ассеты.

Windows и macOS исключены намеренно: упакованные PE ловят эвристики антивирусов, что для инструмента обхода блокировок неприемлемо, а упаковка Mach-O ломает подпись — arm64 macOS такой бинарь просто не запустит.

## README: 725 → 198 строк

Разделы переехали в docs/ целиком, содержание не потеряно:

| Файл | Что забрал |
|---|---|
| `docs/Fallbacks.md` | CF proxy + `--cf-balance`, Worker, фронтинг, default domains, upstream MTProto, inbound FakeTLS, outbound proxy |
| `docs/Building.md` | сборка, zigbuild, кросс-компиляция под OpenWrt, UPX и trade-off |
| `docs/Deployment.md` | Docker, роутер, procd, полный список `TG_*` |

Выкинут только раздел «Project structure» — он разошёлся с кодом (`ProxyConfig` вместо `Config`, нет `outbound/`, `check.rs`, `faketls.rs`), а актуальная версия есть в `AGENTS.md`.

Заодно: образ Docker публикуется на каждом релизе, но в README не упоминался вообще — теперь есть в Quick Start и в `Deployment.md`, с двумя настройками, которые в контейнере реально нужны (`TG_SECRET`, иначе секрет меняется на каждый рестарт, и `--link-ip`, иначе в ссылку попадает адрес бриджа вида `172.17.0.2`). Флаг `--check` был в примерах, но отсутствовал в таблице флагов.

## Прочее

`tokio` без `full` — только те фичи, что реально используются в `src/` и `tests/`. LTO неиспользуемый код и так выкусывал (~16 КБ), так что это не про размер, а про дерево зависимостей: 180 → 172 крейта, ушли `parking_lot`, `signal-hook-registry` и ещё шесть транзитивных.

## Проверено

`cargo clippy --all-targets --locked` чисто, `cargo test --locked` — 187 тестов в 16 бинарях, 0 падений, `cargo fmt --check` чисто, `cargo build --release --locked` собирается. YAML воркфлоу парсится, все внутренние ссылки и якоря в markdown проверены скриптом.

**Чего проверить не удалось:** сам шаг pack+qemu локально не запускается (на macOS нет upx и qemu-user), так что по-настоящему он отработает только на первом реальном теге. Логика проверена статически.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
