### PR TITLE
fix(ci): --repo для заливки ассетов и статическая линковка mips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,26 @@ jobs:
               if: matrix.target == 'mipsel-unknown-linux-musl' || matrix.target == 'mips-unknown-linux-musl'
               run: cargo install cross --locked
 
+            # `+crt-static` is not the default on the mips musl targets the way it
+            # is on every other musl target we ship, so without it these two come
+            # out dynamically linked against /lib/ld-musl-mips*-sf.so.1 — which
+            # contradicts the static binary the docs promise, and breaks outright
+            # if the device's musl variant does not match. Set through --config
+            # rather than RUSTFLAGS so it does not depend on `cross` forwarding
+            # env vars into the container, and applied to std as well via build-std.
             - name: Build (mipsel, build-std)
               if: matrix.target == 'mipsel-unknown-linux-musl'
-              run: cross +nightly build --release --bin tg-ws-proxy --target mipsel-unknown-linux-musl -Z build-std=std,panic_abort
+              run: |
+                  cross +nightly build --release --bin tg-ws-proxy \
+                      --target mipsel-unknown-linux-musl -Z build-std=std,panic_abort \
+                      --config 'target.mipsel-unknown-linux-musl.rustflags=["-C","target-feature=+crt-static"]'
 
             - name: Build (mips, build-std)
               if: matrix.target == 'mips-unknown-linux-musl'
-              run: cross +nightly build --release --bin tg-ws-proxy --target mips-unknown-linux-musl -Z build-std=std,panic_abort
+              run: |
+                  cross +nightly build --release --bin tg-ws-proxy \
+                      --target mips-unknown-linux-musl -Z build-std=std,panic_abort \
+                      --config 'target.mips-unknown-linux-musl.rustflags=["-C","target-feature=+crt-static"]'
 
             - name: Inspect build output (mips variants)
               if: matrix.target == 'mipsel-unknown-linux-musl' || matrix.target == 'mips-unknown-linux-musl'
@@ -79,6 +92,15 @@ jobs:
                   FILE="target/${{ matrix.target }}/release/tg-ws-proxy"
                   ls -lah "target/${{ matrix.target }}/release/" || true
                   test -f "$FILE"
+
+                  # Fail loudly rather than shipping a binary that needs a musl
+                  # loader on the device. A dynamic build still runs on OpenWrt,
+                  # so nothing downstream would have caught this.
+                  file "$FILE"
+                  if readelf -d "$FILE" | grep -q NEEDED; then
+                      echo "::error::$FILE is dynamically linked; expected a static binary"
+                      exit 1
+                  fi
 
             - name: Upload to GitHub Release (mips variants)
               if: matrix.target == 'mipsel-unknown-linux-musl' || matrix.target == 'mips-unknown-linux-musl'
@@ -179,4 +201,5 @@ jobs:
                   echo "${{ matrix.target }}: ${BEFORE} -> ${AFTER} bytes on flash"
 
                   tar -C "$WORK" -czf "${NAME}-upx.tar.gz" tg-ws-proxy
-                  gh release upload "$TAG" "${NAME}-upx.tar.gz" --clobber
+                  gh release upload "$TAG" "${NAME}-upx.tar.gz" \
+                      --repo "${GITHUB_REPOSITORY}" --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"


### PR DESCRIPTION
Чинит релиз `v2.1.0`, где job `compress-assets` отработала впервые и все пять ног упали. Причины две, между собой не связанные, и обе — не про UPX.

## 1. `gh release upload` без `--repo`

aarch64, armv7 и x86_64 **упаковались, прошли `upx -t` и успешно запустились под qemu**, после чего умерли на заливке:

```
+ gh release upload v2.1.0 tg-ws-proxy-aarch64-unknown-linux-musl-upx.tar.gz --clobber
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

В job'е нет `actions/checkout`, поэтому `gh` не может определить репозиторий. В `gh release download` я `--repo` передал, в `upload` — забыл.

Для протокола, упаковка работала: `3768176 -> 1420292` байт (37.7%, формат `linux/arm64`).

## 2. mips и mipsel собирались динамически слинкованными

```
qemu-mipsel-static: Could not open '/lib/ld-musl-mipsel-sf.so.1': No such file or directory
```

Это **предсуществующая проблема**, UPX её только вскрыл. У этих двух целей `crt-static` не является дефолтом, в отличие от всех остальных musl-целей, которые мы выкладываем:

| Target | `crt-static-default` |
|---|---|
| `aarch64-unknown-linux-musl` | `true` |
| `armv7-unknown-linux-musleabihf` | `true` |
| `mips-unknown-linux-musl` | отсутствует |
| `mipsel-unknown-linux-musl` | отсутствует |

(`rustc -Z unstable-options --print target-spec-json`; `crt-static-respected: true` есть у всех, то есть флаг просто нужно выставить.)

То есть выложенные бинари для mips/mipsel требуют `/lib/ld-musl-mips*-sf.so.1` на устройстве. На OpenWrt он есть — поэтому никто и не замечал — но:

- README обещает «single static binary» и «just copy the binary»;
- ломается, если вариант musl на устройстве не совпадает (тот же `-sf` в имени);
- закомментированный блок `[target.mipsel-unknown-linux-musl]` в `.cargo/config.toml` ровно эти rustflags и предполагал, просто в релизной сборке они не применялись.

Теперь оба билда получают `-C target-feature=+crt-static`. Через `cargo --config`, а не `RUSTFLAGS`, чтобы не зависеть от того, прокидывает ли `cross` переменные окружения в контейнер, и чтобы `-Z build-std` применил флаг и к самому std.

Плюс шаг сборки теперь отвергает бинарь с любой записью `DT_NEEDED`:

```
if readelf -d "$FILE" | grep -q NEEDED; then
    echo "::error::$FILE is dynamically linked; expected a static binary"
    exit 1
fi
```

Без этого регрессию тут ничто не поймает: динамический бинарь на OpenWrt работает, и всплыло это только потому, что упакованный бинарь реально запускается под qemu-user, где musl-загрузчика нет.

## Версия и тег

Cargo.toml поднят до **2.1.1**, потому что в `main` уже лежит 2.1.0 и чек `release-version` требует строгого возрастания.

Тег `v2.1.0` остался на remote от неудачного прогона (сам релиз ты удалил). Его надо снести, иначе он висит без релиза:

```
git push origin :refs/tags/v2.1.0
```

Дальше тег `v2.1.1` от `main` после мержа.

## Чего этот PR не доказывает

Собрать mips/mipsel локально я не могу, поэтому что `+crt-static` действительно линкуется, покажет только реальный тег. Риск ограничен: при провале линковки падает нога `upload-assets` для mips, а `compress-assets` стоит под `if: !cancelled()` с `fail-fast: false`, так что остальные ассеты и `-upx` варианты всё равно опубликуются — потеряется максимум пара mips-ассетов, а не релиз.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
