### PR TITLE
feat: add --version flag; publish releases from committed notes

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -139,6 +139,25 @@ jobs:
                       --json assets --jq '.assets[].name' | tee assets.txt
                   grep -q "tg-ws-proxy-dryrun-upx.tar.gz" assets.txt
 
+            # release.yml addresses a draft by tag name in two more places, and
+            # the REST endpoint gh resolves a tag through does not return drafts
+            # -- it relies on gh's fallback over the release list. Exercise both
+            # here so a change in that behaviour surfaces on a pull request and
+            # not on a tag: `compress-assets` downloads the plain asset out of
+            # the still-draft release, and `publish-release` edits it.
+            - name: Confirm a draft can be downloaded from and edited by tag
+              run: |
+                  set -euxo pipefail
+                  gh release download "$DRY_TAG" --repo "${GITHUB_REPOSITORY}" \
+                      --pattern "tg-ws-proxy-dryrun-upx.tar.gz" --dir downloaded
+                  test -s downloaded/tg-ws-proxy-dryrun-upx.tar.gz
+
+                  # Not --draft=false: publishing would create the git tag
+                  # dryrun-<id> in the repository. Any other edit proves the
+                  # same resolution path.
+                  gh release edit "$DRY_TAG" --repo "${GITHUB_REPOSITORY}" \
+                      --title "dry run ${{ github.run_id }} (edited)"
+
             - name: Delete the draft
               if: always()
               run: gh release delete "$DRY_TAG" --repo "${GITHUB_REPOSITORY}" --yes || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ on:
             - v[0-9]+.*
 
 jobs:
+    # Created as a draft: the assets below take minutes to build, and a
+    # published release with no binaries under it is worse than no release yet.
+    # `publish-release` flips it once every asset has landed.
+    #
+    # The body comes from the notes committed alongside the version bump, so a
+    # release cannot ship with the previous version's text or none at all --
+    # `allow-missing-changelog` stays false, which fails the release instead.
+    # The heading in that file must be a bare `# vX.Y.Z`: parse-changelog does
+    # not recognise a version heading carrying the crate name, with or without
+    # `prefix-format`. The name lives in `title` instead.
     create-release:
         runs-on: ubuntu-latest
         steps:
@@ -16,6 +26,9 @@ jobs:
             - uses: taiki-e/create-gh-release-action@v1
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
+                  changelog: docs/release-notes/$version.md
+                  title: tg-ws-proxy-rs $tag
+                  draft: true
 
     upload-assets:
         needs: create-release
@@ -196,3 +209,18 @@ jobs:
                   tar -C "$WORK" -czf "${NAME}-upx.tar.gz" tg-ws-proxy
                   gh release upload "$TAG" "${NAME}-upx.tar.gz" \
                       --repo "${GITHUB_REPOSITORY}" --clobber
+
+    # Both `needs` must succeed, so a target that failed to build leaves the
+    # release a draft rather than publishing a half-populated one. Finish the
+    # job by hand (or re-run the failed leg) and the draft is still there.
+    publish-release:
+        needs: [upload-assets, compress-assets]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Publish the draft now that every asset is uploaded
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euxo pipefail
+                  gh release edit "${GITHUB_REF_NAME}" \
+                      --repo "${GITHUB_REPOSITORY}" --draft=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,35 @@ builds. **Any change destined for `main` must bump the `version` field in `Cargo
 `cargo build` regenerate the matching line in `Cargo.lock`) — the CI job `release-version` fails
 the PR otherwise.
 
+## Releases
+
+Pushing a `v*` tag runs `.github/workflows/release.yml`, which needs nothing done by hand
+afterwards — **but the release notes have to be in the commit being tagged.**
+
+**Every PR that bumps the version also writes `docs/release-notes/<version>.md`** (no `v`, e.g.
+`docs/release-notes/2.2.2.md`). `create-release` feeds that file to `parse-changelog` and uses the
+result as the release body; `allow-missing-changelog` is left at `false`, so a missing or
+misnamed file fails the release *after* the tag has been pushed. Two constraints on the file:
+
+- **The heading must be a bare `# vX.Y.Z`.** `# tg-ws-proxy-rs v2.2.2` is not recognised as a
+  version heading, and `prefix-format` does not fix it. The crate name lives in the workflow's
+  `title:` input. Everything below the heading is the body verbatim, so `##` sections, tables and
+  `<details>` blocks work — match the tone of the existing notes: what changed, why it matters,
+  and honestly what it costs.
+- **Check it before tagging** with `parse-changelog docs/release-notes/<version>.md <version>`,
+  which prints exactly what the release will show.
+
+If a version is bumped past without ever being tagged, **fold its notes into the new version's
+file** rather than leaving both — only the tagged version's file is ever read, and the skipped
+one's changes would silently go unannounced.
+
+The release is created as a draft and published by the `publish-release` job only once every
+asset (plain and UPX) has uploaded. A failed target therefore leaves a draft rather than a
+half-populated public release: fix or re-run the failed leg, and the same draft is completed and
+published. Anything in `release.yml` that addresses the release by tag name is addressing a draft
+— `.github/workflows/release-dryrun.yml` rehearses those calls on pull requests, so add a
+rehearsal there when adding one.
+
 ## Conventions to follow
 
 - **CLI flags mirror env vars.** Every `#[arg(...)]` in `config.rs` has an `env = "TG_*"` fallback.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ tg-ws-proxy [OPTIONS]
 | `-q / --quiet` | off | Suppress all log output |
 | `-v / --verbose` | off | Debug logging |
 | `--danger-accept-invalid-certs` | off | Skip TLS verification |
+| `-V / --version` | — | Print the version and exit |
 
 Every flag has a matching `TG_*` environment variable (`TG_PORT`, `TG_HOST`,
 `TG_SECRET`, …) — the full list is in

--- a/docs/release-notes/2.2.2.md
+++ b/docs/release-notes/2.2.2.md
@@ -1,0 +1,56 @@
+# v2.2.2
+
+One flag, and the release notes you are reading now ship from the repository
+instead of being pasted in by hand afterwards.
+
+**No configuration changes.** Every existing CLI flag and `TG_*` variable behaves
+exactly as it did in v2.2.1, and the library API is unchanged. Drop-in swap on
+every target.
+
+## New
+
+**`tg-ws-proxy --version` now prints the version and exits**, along with the
+short form `-V`:
+
+```console
+$ tg-ws-proxy --version
+tg-ws-proxy 2.2.2
+```
+
+Previously both were rejected as an unknown argument. The version *was* already
+available — the startup banner has always carried it — but only by actually
+starting the proxy, which means binding the port and finding a free one to bind.
+And the banner is an `info!` log line, so `--quiet` drops it entirely and
+`--log-file` sends it to the file instead of the terminal. On a router, where
+the binary is copied around by hand and the running one is whatever was `scp`'d
+last, that made "which build is this?" a harder question than it should be.
+
+The value comes from `CARGO_PKG_VERSION` at compile time, so it is the version
+in `Cargo.toml` by construction and cannot drift from the release tag.
+
+**`-v` is untouched.** Short flags are case-sensitive: `-v` is still
+`--verbose`, `-V` is `--version`. Nothing that already worked changes meaning.
+
+## Changed
+
+**Releases now publish complete, or not at all.** The GitHub Release used to be
+created the moment the tag landed and then filled in over the following minutes
+as each target finished building — so for a while it sat there advertising a new
+version with no binaries under it, and the notes arrived even later, by hand.
+
+It is now created as a draft and flipped to published only after every asset,
+plain and UPX-packed alike, has been uploaded. The body comes from
+`docs/release-notes/$version.md`, committed in the same pull request that bumps
+the version. Forgetting to write it fails the release rather than shipping an
+empty one.
+
+Nothing about the produced binaries changes — this is release plumbing only.
+
+## Verified
+
+188 tests, clean `cargo clippy --all-targets`, clean `cargo fmt`. Both flags are
+covered by a test that asserts the printed string contains the crate version, so
+a future rename or a hand-written version string cannot silently break them.
+
+The release rehearsal that runs on pull requests now also downloads from and
+edits a draft release, which is what the publish-at-the-end flow depends on.

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,6 +122,7 @@ fn parse_dc_ip(s: &str) -> Result<(u32, String), String> {
 #[derive(Parser, Clone, Debug)]
 #[command(
     name = "tg-ws-proxy",
+    version,
     about = "Telegram MTProto WebSocket Bridge Proxy",
     long_about = "Local MTProto proxy that tunnels Telegram Desktop traffic \
                   through WebSocket connections to Telegram DCs.\n\

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -397,3 +397,17 @@ fn cf_worker_domains_accept_repeated_flags_including_alias() {
         ]
     );
 }
+
+#[test]
+fn version_flag_prints_the_crate_version() {
+    for flag in ["--version", "-V"] {
+        let err = Config::try_parse_from(["tg-ws-proxy", flag]).unwrap_err();
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+        assert!(
+            err.to_string().contains(env!("CARGO_PKG_VERSION")),
+            "{flag} output {:?} does not contain the crate version",
+            err.to_string()
+        );
+    }
+}


### PR DESCRIPTION
## Что

Два изменения, которые пришлось объединить в один PR — см. «Почему вместе» ниже.

### 1. `--version`

`tg-ws-proxy --version` (и короткий `-V`) теперь печатает версию и выходит — раньше clap отвечал `unexpected argument`. Реализовано встроенным `version` в `#[command(...)]`, значение берётся из `CARGO_PKG_VERSION`, так что разъехаться с `Cargo.toml` не может.

```
$ tg-ws-proxy --version
tg-ws-proxy 2.2.2
```

`-v` не задет: короткие флаги регистрозависимы, `-v` — `--verbose`, `-V` — `--version`.

### 2. Релизы публикуются сами и целиком

Сейчас релиз создаётся в момент пуша тега и наполняется ассетами следующие несколько минут — то есть какое-то время висит новая версия без единого бинарника, а заметки доезжают ещё позже, руками.

- `create-release` создаёт **драфт**, новая джоба `publish-release` снимает драфт только после того, как отработали и `upload-assets`, и `compress-assets`. Оба `needs` должны быть успешны, так что упавший таргет оставляет релиз драфтом, а не публикует наполовину.
- Тело релиза берётся из `docs/release-notes/$version.md`, закоммиченного вместе с бампом версии. `allow-missing-changelog` остаётся `false` — забытая заметка роняет релиз, а не публикует пустой.

## Почему вместе

`release-version` в `ci.yml` требует бампа версии на **каждом** PR, без фильтра по путям. Отдельный CI-PR после этого обязан был бы стать 2.2.3 — то есть либо v2.2.2 выходит по старой схеме с ручной вставкой заметок, либо номер сгорает впустую. Так релиз 2.2.2 сразу едет по новой схеме.

## Что проверено руками, а не предположено

- **Формат заголовка.** `# tg-ws-proxy-rs v2.2.2` parse-changelog **не** распознаёт — ни как есть, ни с `--prefix-format` (проверил четыре варианта). Работает `# v2.2.2`; заголовок при этом вырезается из тела, поэтому имя крейта переехало в `title: tg-ws-proxy-rs $tag`. Прогнал `parse-changelog docs/release-notes/2.2.2.md 2.2.2` — извлекается всё тело, включая `##`-секции.
- **Драфт по имени тега.** REST-эндпоинт, через который gh резолвит тег, драфты не возвращает — gh полагается на фоллбэк перебором списка релизов. `upload` и `view` это уже подтверждал dry run; добавил туда `download` и `edit`, потому что на них завязаны `compress-assets` и `publish-release`. Публикацию в dry run не проверяю — `--draft=false` создал бы в репозитории тег `dryrun-<id>`.
- 188 тестов, чистые `cargo clippy --all-targets` и `cargo fmt`, бинарник запущен с обоими флагами.

## Чего в PR нет

`allow-missing-changelog` не трогал (остаётся `false` — это и есть страховка), старые релизы задним числом в `docs/release-notes/` не переносил.

🤖 Generated with [Claude Code](https://claude.com/claude-code)