### PR TITLE
fix(docker): build the proxy instead of shipping the dependency-layer stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,34 @@ RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
 COPY src ./src
 COPY crates ./crates
 
+# `touch` before building, and it is load-bearing. `COPY` preserves the build
+# context's mtimes, and a fresh checkout's are older than the dependency layer
+# above, which ran minutes later inside this build. Cargo decides freshness by
+# mtime, so it compares the real sources against the stub's artifacts, calls
+# everything up to date, does nothing, and leaves `fn main() {}` sitting in
+# target/release/tg-ws-proxy for the `cp` below to ship. That is what happened
+# to 2.3.0: a 300 KB image whose entrypoint exits 0 without listening.
+#
+# The trap only springs when the layer above actually executes rather than
+# coming from cache, which is why it stayed hidden until a release changed
+# Cargo.toml, Cargo.lock and that layer's command all at once.
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git \
     --mount=type=cache,id=target-${TARGETPLATFORM},target=/app/target \
+    find src crates -name '*.rs' -exec touch {} + && \
     cargo build --release --locked && \
     cp target/release/tg-ws-proxy /usr/local/bin/tg-ws-proxy
+
+# The stub is a valid binary that exits 0, so no later step -- not the COPY into
+# scratch, not the image size, not a smoke test that only checks the container
+# starts -- can tell it from the real one. Ask the binary what it is, and fail
+# the build here rather than on someone's router.
+RUN expected="tg-ws-proxy $(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)" && \
+    actual="$(/usr/local/bin/tg-ws-proxy --version)" && \
+    if [ "$actual" != "$expected" ]; then \
+        echo "built binary reports '$actual', expected '$expected'" >&2; \
+        exit 1; \
+    fi
 
 FROM scratch AS runtime
 

--- a/docs/release-notes/2.3.1.md
+++ b/docs/release-notes/2.3.1.md
@@ -1,0 +1,35 @@
+# v2.3.1
+
+Fixes the Docker image published for 2.3.0, which did not contain the proxy.
+
+## What went wrong
+
+The 2.3.0 image was 300 KB instead of ~2.2 MB and its entrypoint exited 0
+immediately, so the container "started" and stopped with an empty log whatever
+flags it was given ([#117](https://github.com/valnesfjord/tg-ws-proxy-rs/issues/117)).
+
+The Dockerfile builds dependencies in their own layer first, against a stub
+`fn main() {}`, so that a source-only change does not recompile the dependency
+tree. `COPY` then restores the real sources — with the mtimes they carry in the
+build context, which for a fresh checkout are *older* than the stub layer that
+ran minutes later inside the same build. Cargo decides freshness by mtime,
+compared the real sources against the stub's artifacts, found them older,
+declared the crate up to date, and did nothing. The `cp` that follows shipped
+the stub.
+
+The trap only springs when that dependency layer actually executes instead of
+coming from cache, which is why it stayed hidden until a release changed
+`Cargo.toml`, `Cargo.lock` and the layer's own command at the same time.
+
+## Fixed
+
+- The real sources are touched after `COPY` and before the build, so cargo sees
+  them as newer than anything the dependency layer left behind.
+- The builder now asks the binary it just produced for `--version` and fails the
+  build unless it matches `Cargo.toml`. A stub is a valid binary that exits 0,
+  so image size, a successful build and a container that starts all look
+  identical either way — the only thing that can tell them apart is asking.
+
+No source, CLI, protocol or Android change. Binaries, APKs and OpenWrt packages
+published for 2.3.0 were built by a different path and were never affected;
+only the Docker image was.


### PR DESCRIPTION
Closes #117.

The 2.3.0 image on Docker Hub is **300 KB** against 2.2.5's **2242 KB**, and its entrypoint exits 0 immediately — the container "starts", stops, and writes nothing to the log whatever flags it gets. `latest` points at it too, so everyone pulling right now gets it.

## What it actually contains

The `fn main() {}` stub from the dependency-cache layer. That layer builds dependencies against a stub so a source-only change does not recompile the tree; `COPY` then restores the real sources — carrying the build context's mtimes, which for a fresh checkout are **older** than the stub layer that ran minutes later inside the same build.

Cargo decides freshness by mtime. It compared the real sources against the stub's artifacts, found them older, declared the crate up to date, and did nothing. The `cp` after it shipped the stub.

Reproduced outside Docker:

```
заглушка: 302704 байт          <- exactly the published image
--- вторая сборка ---
    Finished `release` profile [optimized] target(s) in 0.04s
после: 302704 байт
```

With the fix, the same sequence recompiles for 23s and yields 3.7 MB reporting `tg-ws-proxy 2.3.1`.

The trap has been in this Dockerfile all along; it only springs when the dependency layer actually executes instead of coming from cache. 2.3.0 changed `Cargo.toml`, `Cargo.lock` and that layer's command at once, so the miss was guaranteed.

## Fix

- `touch` the sources after `COPY`, before the build.
- The builder asks the binary it produced for `--version` and fails unless it matches `Cargo.toml`. A stub is a valid binary that exits 0 — image size, a green build and a container that starts look identical either way. Asking is the only thing that distinguishes them.

## Scope

No source, CLI, protocol or Android change. Binaries, APKs and OpenWrt packages are built by a different path and were never affected — only the Docker image.

## Republishing

Merging this fixes `latest` (docker.yml publishes it on push to main). The `2.3.0` and `2.3` tags stay broken until either a `v2.3.1` tag is cut or the Docker workflow is dispatched manually for them.