### PR TITLE
Remove `DependencyInfoBlock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "tg-ws-proxy-rs"
-version = "2.3.2"
+version = "2.3.3"
 dependencies = [
  "aes",
  "async-http-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-ws-proxy-rs"
-version = "2.3.2"
+version = "2.3.3"
 edition = "2024"
 description = "Telegram MTProto WebSocket Bridge Proxy — Rust port of Flowseal/tg-ws-proxy"
 license = "MIT"
@@ -13,7 +13,7 @@ categories = ["network-programming", "command-line-utilities"]
 
 [package.metadata.android]
 # This must match (MAJOR * 10000 + MINOR * 100 + PATCH) * 10.
-version_code = 203020
+version_code = 203030
 
 # The JNI shim is a separate crate because `crate-type` is a per-package
 # setting: a `["lib", "cdylib"]` root made every desktop and Docker

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,6 +10,13 @@ android {
     defaultConfig {
         applicationId = "io.github.valnesfjord.tgwsproxyrs"
     }
+
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 dependencies {

--- a/docs/release-notes/2.3.3.md
+++ b/docs/release-notes/2.3.3.md
@@ -1,0 +1,27 @@
+# v2.3.3
+
+Android: drop the `DependencyInfoBlock` from release APKs so F-Droid accepts
+updates again. No functional changes to the proxy itself — desktop binaries and
+Docker images are unaffected.
+
+## Why
+
+AGP injects a `DependencyInfoBlock` into every APK it builds — a v2
+[signing block](https://source.android.com/docs/security/apksigning/v2)
+encrypted with Google's public key, so only Google can read it. F-Droid
+[recently started scanning](https://gitlab.com/fdroid/fdroidserver/-/issues/1056)
+updates (not just new apps) for this block and rejects APKs that carry it,
+which would have blocked every future update of the Android app.
+
+## Changes
+
+- **Disabled dependency metadata in the Android build**
+  (`android/app/build.gradle.kts`): `dependenciesInfo.includeInApk = false` and
+  `includeInBundle = false`, so neither APKs nor App Bundles carry the block.
+- Version bump to 2.3.3 (version code `203030`).
+
+## What it costs
+
+Google Play uses this block to track dependency versions across app updates.
+This app is distributed through F-Droid and GitHub Releases, never Play, so
+nothing is lost — the metadata only ever served Google.


### PR DESCRIPTION
https://gitlab.com/ygsk-tor/fdroiddata/-/jobs/16190213340

Part of #115.

I find that there is a `DependencyInfoBlock` in your APK.

It's a [Signing block](https://source.android.com/docs/security/features/apksigning/v2#apk-signing-block) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367) and [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056).

While this was added a while ago, F-Droid were only enforcing it for new apps, and recently they started scanning updates too.

I have disabled it with the following code.

```
android {
    dependenciesInfo {
        // Disables dependency metadata when building APKs.
        includeInApk = false
        // Disables dependency metadata when building Android App Bundles.
        includeInBundle = false
    }
}
```

I'll need a new release with this fix.